### PR TITLE
Handling of cvxpy failures when computing cvxpy_fit

### DIFF
--- a/qiskit_ignis/tomography/fitters/cvx_fit.py
+++ b/qiskit_ignis/tomography/fitters/cvx_fit.py
@@ -234,7 +234,25 @@ def cvx_fit(data, basis_matrix, weights=None, PSD=True, trace=None,
 
     # Solve SDP
     prob = cvxpy.Problem(obj, cons)
-    prob.solve(**kwargs)
+    iters = 5000
+    max_iters = kwargs.get('max_iters', 20000)
+
+    problem_solved = False
+    while not problem_solved:
+        kwargs['max_iters'] = iters
+        prob.solve(**kwargs)
+        if prob.status in ["optimal_inaccurate", "optimal"]:
+            problem_solved = True
+        elif prob.status == "unbounded_inaccurate":
+            if iters < max_iters:
+                iters *= 2
+            else:
+                raise RuntimeError("CVX fit failed, probably not enough iterations for the solver")
+        elif prob.status in ["infeasible", "unbounded"]:
+            raise RuntimeError("CVX fit failed, problem status {} which should not happen".format(prob.status))
+        else:
+            raise RuntimeError("CVX fit failed, reason unknown")
+
     rho_fit = rho_r.value + 1j * rho_i.value
 
     return rho_fit


### PR DESCRIPTION
Currently, cvx_fit does not check the success of the `prob.solve()` call. When the solver fails, this results in a crash on the following line:

`rho_fit = rho_r.value + 1j * rho_i.value`

The purpose of this pull request is to provide better error messages and handling of this situation.

The linear program solved by cvxpy is supposed to be feasible and bounded, hence those cases are reported as "should not happen"; they indicate a problem in the code of `cvx_fit` itself. 

On the other hand,  the cvxpy solver returns "unbounded_inaccurate" whenever it terminates prematurely due to a low number of iterations (set in kwargs['max_iters']). Hence, we attempt to recover from such a failure by doubling twice the number of iterations and rerunning the solver before giving up. The numbers were chosen according to the cvxpy default of 5000 iterations. If the user supplies `max_iters` we do not attempt the double-and-retry technique.