### PR TITLE
update fitter_data function

### DIFF
--- a/examples/process-tomography.ipynb
+++ b/examples/process-tomography.ipynb
@@ -7,9 +7,7 @@
     "# Quantum Process Tomography\n",
     "\n",
     "* **Last Updated:** Jan 24, 2019\n",
-    "* **Requires:**\n",
-    "  * qiskit-terra 0.7\n",
-    "  * qiskit-aer 0.1"
+    "* **Requires:** qiskit-terra 0.7"
    ]
   },
   {
@@ -50,17 +48,17 @@
      "data": {
       "text/plain": [
        "{(('Zp',), ('X',)): {'0': 4000},\n",
-       " (('Zp',), ('Y',)): {'1': 2043, '0': 1957},\n",
-       " (('Zp',), ('Z',)): {'1': 1955, '0': 2045},\n",
+       " (('Zp',), ('Y',)): {'1': 1960, '0': 2040},\n",
+       " (('Zp',), ('Z',)): {'1': 1979, '0': 2021},\n",
        " (('Zm',), ('X',)): {'1': 4000},\n",
-       " (('Zm',), ('Y',)): {'1': 1989, '0': 2011},\n",
-       " (('Zm',), ('Z',)): {'1': 2024, '0': 1976},\n",
-       " (('Xp',), ('X',)): {'1': 1982, '0': 2018},\n",
-       " (('Xp',), ('Y',)): {'1': 2014, '0': 1986},\n",
+       " (('Zm',), ('Y',)): {'1': 2031, '0': 1969},\n",
+       " (('Zm',), ('Z',)): {'1': 1978, '0': 2022},\n",
+       " (('Xp',), ('X',)): {'1': 1993, '0': 2007},\n",
+       " (('Xp',), ('Y',)): {'1': 2004, '0': 1996},\n",
        " (('Xp',), ('Z',)): {'0': 4000},\n",
-       " (('Yp',), ('X',)): {'1': 1997, '0': 2003},\n",
+       " (('Yp',), ('X',)): {'1': 2024, '0': 1976},\n",
        " (('Yp',), ('Y',)): {'1': 4000},\n",
-       " (('Yp',), ('Z',)): {'1': 1958, '0': 2042}}"
+       " (('Yp',), ('Z',)): {'1': 2098, '0': 1902}}"
       ]
      },
      "execution_count": 2,
@@ -99,30 +97,29 @@
      "output_type": "stream",
      "text": [
       "MLE Fitter\n",
-      "fit time: 0.16478204727172852\n",
-      "fit fidelity: 0.9927145287905677\n",
+      "fit time: 0.1457839012145996\n",
+      "fit fidelity: 0.9902245017121254\n",
       "\n",
       "CVXOPT Fitter\n",
-      "fit time: 0.07139205932617188\n",
-      "fit fidelity: 0.9999595309349295\n"
+      "fit time: 0.03708195686340332\n",
+      "fit fidelity: 0.9998921264767937\n"
      ]
     }
    ],
    "source": [
     "# Extract fitter data from tomography counts\n",
-    "data, basis = tomo.fitter_data(qpt_counts)\n",
+    "data, basis, weights = tomo.fitter_data(qpt_counts)\n",
     "\n",
     "# MLE Least-Squares tomographic reconstruction\n",
     "t = time.time()\n",
-    "choi_mle = tomo.process_mle_fit(data, basis)\n",
+    "choi_mle = tomo.process_mle_fit(data, basis, weights)\n",
     "print('MLE Fitter')\n",
     "print('fit time:', time.time() - t)\n",
     "print('fit fidelity:', state_fidelity(choi_ideal / 2, choi_mle / 2))\n",
     "\n",
     "# CVXOPT Semidefinite-Program tomographic reconstruction\n",
     "t = time.time()\n",
-    "choi_cvx = tomo.fitters.cvx_fit(data, basis, PSD=True, trace_preserving=True, trace=2)\n",
-    "choi_cvx = tomo.process_cvx_fit(data, basis)\n",
+    "choi_cvx = tomo.process_cvx_fit(data, basis, weights)\n",
     "print('\\nCVXOPT Fitter')\n",
     "print('fit time:', time.time() - t)\n",
     "print('fit fidelity:', state_fidelity(choi_ideal / 2, choi_cvx / 2))"
@@ -145,18 +142,18 @@
     {
      "data": {
       "text/plain": [
-       "{(('Zp',), ('X',)): {'1': 987, '0': 1013},\n",
-       " (('Zp',), ('Y',)): {'1': 985, '0': 1015},\n",
+       "{(('Zp',), ('X',)): {'1': 997, '0': 1003},\n",
+       " (('Zp',), ('Y',)): {'1': 989, '0': 1011},\n",
        " (('Zp',), ('Z',)): {'0': 2000},\n",
-       " (('Zm',), ('X',)): {'1': 975, '0': 1025},\n",
-       " (('Zm',), ('Y',)): {'1': 978, '0': 1022},\n",
+       " (('Zm',), ('X',)): {'1': 1011, '0': 989},\n",
+       " (('Zm',), ('Y',)): {'1': 1039, '0': 961},\n",
        " (('Zm',), ('Z',)): {'1': 2000},\n",
        " (('Xp',), ('X',)): {'0': 2000},\n",
-       " (('Xp',), ('Y',)): {'1': 1027, '0': 973},\n",
-       " (('Xp',), ('Z',)): {'1': 969, '0': 1031},\n",
-       " (('Yp',), ('X',)): {'1': 1020, '0': 980},\n",
+       " (('Xp',), ('Y',)): {'1': 996, '0': 1004},\n",
+       " (('Xp',), ('Z',)): {'1': 1019, '0': 981},\n",
+       " (('Yp',), ('X',)): {'1': 1006, '0': 994},\n",
        " (('Yp',), ('Y',)): {'0': 2000},\n",
-       " (('Yp',), ('Z',)): {'1': 1010, '0': 990}}"
+       " (('Yp',), ('Z',)): {'1': 972, '0': 1028}}"
       ]
      },
      "execution_count": 4,
@@ -194,30 +191,29 @@
      "output_type": "stream",
      "text": [
       "MLE Fitter\n",
-      "fit time: 0.0012328624725341797\n",
-      "fit fidelity: 0.9820372305628304\n",
+      "fit time: 0.0014650821685791016\n",
+      "fit fidelity: 0.9956917452151154\n",
       "\n",
       "CVXOPT Fitter\n",
-      "fit time: 0.0461270809173584\n",
-      "fit fidelity: 0.9999537962913683\n"
+      "fit time: 0.028470993041992188\n",
+      "fit fidelity: 0.9999552921830998\n"
      ]
     }
    ],
    "source": [
     "# Extract fitter data from tomography counts\n",
-    "data, basis = tomo.fitter_data(qpt_counts)\n",
+    "data, basis, weights = tomo.fitter_data(qpt_counts)\n",
     "\n",
     "# MLE Least-Squares tomographic reconstruction\n",
     "t = time.time()\n",
-    "choi_mle = tomo.process_mle_fit(data, basis)\n",
+    "choi_mle = tomo.process_mle_fit(data, basis, weights)\n",
     "print('MLE Fitter')\n",
     "print('fit time:', time.time() - t)\n",
     "print('fit fidelity:', state_fidelity(choi_ideal / 2, choi_mle / 2))\n",
     "\n",
     "# CVXOPT Semidefinite-Program tomographic reconstruction\n",
     "t = time.time()\n",
-    "choi_cvx = tomo.fitters.cvx_fit(data, basis, PSD=True, trace_preserving=True, trace=2)\n",
-    "choi_cvx = tomo.process_cvx_fit(data, basis)\n",
+    "choi_cvx = tomo.process_cvx_fit(data, basis, weights)\n",
     "print('\\nCVXOPT Fitter')\n",
     "print('fit time:', time.time() - t)\n",
     "print('fit fidelity:', state_fidelity(choi_ideal / 2, choi_cvx / 2))"
@@ -240,12 +236,12 @@
      "output_type": "stream",
      "text": [
       "MLE Fitter\n",
-      "fit time: 0.028927087783813477\n",
-      "fit fidelity: 0.9840922722224257\n",
+      "fit time: 0.04158282279968262\n",
+      "fit fidelity: 0.9834101265402414\n",
       "\n",
       "CVXOPT Fitter\n",
-      "fit time: 1.2832000255584717\n",
-      "fit fidelity: 0.999908669144743\n"
+      "fit time: 1.961974859237671\n",
+      "fit fidelity: 0.9999306422410397\n"
      ]
     }
    ],
@@ -270,17 +266,17 @@
     "qpt_counts = tomo.tomography_data(job.result(), qpt_circs)\n",
     "\n",
     "# Extract fitter data from tomography counts\n",
-    "data, basis = tomo.fitter_data(qpt_counts)\n",
+    "data, basis, weights = tomo.fitter_data(qpt_counts)\n",
     "\n",
     "\n",
     "t = time.time()\n",
-    "choi_mle = tomo.process_mle_fit(data, basis)\n",
+    "choi_mle = tomo.process_mle_fit(data, basis, weights)\n",
     "print('MLE Fitter')\n",
     "print('fit time:', time.time() - t)\n",
     "print('fit fidelity:', state_fidelity(choi_ideal / 4, choi_mle / 4))\n",
     "\n",
     "t = time.time()\n",
-    "choi_cvx = tomo.process_cvx_fit(data, basis)\n",
+    "choi_cvx = tomo.process_cvx_fit(data, basis, weights)\n",
     "print('\\nCVXOPT Fitter')\n",
     "print('fit time:', time.time() - t)\n",
     "print('fit fidelity:', state_fidelity(choi_ideal / 4, choi_cvx / 4))"
@@ -302,17 +298,17 @@
      "data": {
       "text/plain": [
        "{(('S0',), ('X',)): {'0': 2000},\n",
-       " (('S0',), ('Y',)): {'1': 966, '0': 1034},\n",
-       " (('S0',), ('Z',)): {'1': 1036, '0': 964},\n",
-       " (('S1',), ('X',)): {'1': 1332, '0': 668},\n",
-       " (('S1',), ('Y',)): {'1': 1026, '0': 974},\n",
+       " (('S0',), ('Y',)): {'1': 1010, '0': 990},\n",
+       " (('S0',), ('Z',)): {'1': 989, '0': 1011},\n",
+       " (('S1',), ('X',)): {'1': 1345, '0': 655},\n",
+       " (('S1',), ('Y',)): {'1': 965, '0': 1035},\n",
        " (('S1',), ('Z',)): {'1': 60, '0': 1940},\n",
-       " (('S2',), ('X',)): {'1': 1342, '0': 658},\n",
-       " (('S2',), ('Y',)): {'1': 166, '0': 1834},\n",
-       " (('S2',), ('Z',)): {'1': 1503, '0': 497},\n",
-       " (('S3',), ('X',)): {'1': 1351, '0': 649},\n",
-       " (('S3',), ('Y',)): {'1': 1823, '0': 177},\n",
-       " (('S3',), ('Z',)): {'1': 1446, '0': 554}}"
+       " (('S2',), ('X',)): {'1': 1314, '0': 686},\n",
+       " (('S2',), ('Y',)): {'1': 191, '0': 1809},\n",
+       " (('S2',), ('Z',)): {'1': 1468, '0': 532},\n",
+       " (('S3',), ('X',)): {'1': 1345, '0': 655},\n",
+       " (('S3',), ('Y',)): {'1': 1826, '0': 174},\n",
+       " (('S3',), ('Z',)): {'1': 1419, '0': 581}}"
       ]
      },
      "execution_count": 7,
@@ -351,29 +347,29 @@
      "output_type": "stream",
      "text": [
       "MLE Fitter\n",
-      "fit time: 0.0009930133819580078\n",
-      "fit fidelity: 0.9937348052238946\n",
+      "fit time: 0.002043008804321289\n",
+      "fit fidelity: 0.9923398831786698\n",
       "\n",
       "CVXOPT Fitter\n",
-      "fit time: 0.025810956954956055\n",
-      "fit fidelity: 0.99903075629802\n"
+      "fit time: 0.07675480842590332\n",
+      "fit fidelity: 0.9938897085080838\n"
      ]
     }
    ],
    "source": [
     "# Extract fitter data from tomography counts\n",
-    "data, basis = tomo.fitter_data(qpt_counts, prep_basis='SIC')\n",
+    "data, basis, weights = tomo.fitter_data(qpt_counts, prep_basis='SIC')\n",
     "\n",
     "# MLE Least-Squares tomographic reconstruction\n",
     "t = time.time()\n",
-    "choi_mle = tomo.process_mle_fit(data, basis)\n",
+    "choi_mle = tomo.process_mle_fit(data, basis, weights)\n",
     "print('MLE Fitter')\n",
     "print('fit time:', time.time() - t)\n",
     "print('fit fidelity:', state_fidelity(choi_ideal / 2, choi_mle / 2))\n",
     "\n",
     "# CVXOPT Semidefinite-Program tomographic reconstruction\n",
     "t = time.time()\n",
-    "choi_cvx = tomo.process_cvx_fit(data, basis)\n",
+    "choi_cvx = tomo.process_cvx_fit(data, basis, weights)\n",
     "\n",
     "print('\\nCVXOPT Fitter')\n",
     "print('fit time:', time.time() - t)\n",

--- a/examples/state-tomography.ipynb
+++ b/examples/state-tomography.ipynb
@@ -7,14 +7,12 @@
     "# Quantum State Tomography\n",
     "\n",
     "* **Last Updated:** Jan 24, 2019\n",
-    "* **Requires:**\n",
-    "  * qiskit-terra 0.7\n",
-    "  * qiskit-aer 0.1"
+    "* **Requires:** qiskit-terra 0.7"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,10 +24,6 @@
     "import qiskit \n",
     "from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister, Aer\n",
     "from qiskit.quantum_info import state_fidelity\n",
-    "\n",
-    "# Import Qiskit Aer Noise\n",
-    "from qiskit.providers.aer.noise import NoiseModel\n",
-    "from qiskit.providers.aer.noise.errors import *\n",
     "\n",
     "# Tomography functions\n",
     "import sys, os\n",
@@ -46,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -78,31 +72,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken: 0.2506849765777588\n"
+      "Time taken: 0.25657010078430176\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{('X', 'X'): {'11': 2486, '00': 2514},\n",
-       " ('X', 'Y'): {'01': 1225, '11': 1235, '10': 1256, '00': 1284},\n",
-       " ('X', 'Z'): {'01': 1236, '11': 1242, '10': 1288, '00': 1234},\n",
-       " ('Y', 'X'): {'01': 1283, '11': 1229, '10': 1261, '00': 1227},\n",
-       " ('Y', 'Y'): {'01': 2461, '10': 2539},\n",
-       " ('Y', 'Z'): {'01': 1347, '11': 1228, '10': 1165, '00': 1260},\n",
-       " ('Z', 'X'): {'01': 1281, '11': 1233, '10': 1211, '00': 1275},\n",
-       " ('Z', 'Y'): {'01': 1232, '11': 1280, '10': 1255, '00': 1233},\n",
-       " ('Z', 'Z'): {'11': 2547, '00': 2453}}"
+       "{('X', 'X'): {'00': 2545, '11': 2455},\n",
+       " ('X', 'Y'): {'10': 1269, '00': 1215, '01': 1261, '11': 1255},\n",
+       " ('X', 'Z'): {'10': 1203, '00': 1242, '01': 1316, '11': 1239},\n",
+       " ('Y', 'X'): {'10': 1287, '00': 1250, '01': 1243, '11': 1220},\n",
+       " ('Y', 'Y'): {'10': 2563, '01': 2437},\n",
+       " ('Y', 'Z'): {'10': 1222, '00': 1293, '01': 1265, '11': 1220},\n",
+       " ('Z', 'X'): {'10': 1242, '00': 1259, '01': 1287, '11': 1212},\n",
+       " ('Z', 'Y'): {'10': 1179, '00': 1251, '01': 1288, '11': 1282},\n",
+       " ('Z', 'Z'): {'00': 2486, '11': 2514}}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -124,177 +118,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fit Fidelity = 0.9999583056919802\n"
+      "Fit Fidelity = 0.999930554744795\n"
      ]
     }
    ],
    "source": [
     "# Generate fitter data and reconstruct density matrix\n",
-    "probs_bell, basis_matrix_bell = tomo.fitter_data(tomo_counts_bell)\n",
-    "rho_bell = tomo.state_cvx_fit(probs_bell, basis_matrix_bell)\n",
+    "probs_bell, basis_matrix_bell, weights_bell = tomo.fitter_data(tomo_counts_bell)\n",
+    "rho_bell = tomo.state_cvx_fit(probs_bell, basis_matrix_bell, weights_bell)\n",
     "F_bell = state_fidelity(psi_bell, rho_bell)\n",
     "print('Fit Fidelity =', F_bell)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Including Calibration Error (Simulated)\n",
-    "\n",
-    "Suppose we include T1 relaxation during measurement, but all other circuit operations are perfect.\n",
-    "Noise parameters:\n",
-    "* measurement time: 5 microseconds\n",
-    "* T_1: 50 microseconds\n",
-    "* Population of excited state: 5%\n",
-    "\n",
-    "The assignment fidelity for this can be calculated from\n",
-    "* P(0|0) = 1 - P(1|0)\n",
-    "* P(1|0) = pop1 * exp(- t_meas / t_1)\n",
-    "* P(0|1) = (1 - pop1) * exp(- t_meas / t_1)\n",
-    "* P(1|1) = 1 - P(0|1)\n",
-    "\n",
-    "the calibration error matrix is\n",
-    "M = [[P(0|0), P(0|1)], [P(1|0), P(1|1)]]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{('X', 'X'): {'01': 218, '11': 2107, '10': 245, '00': 2430},\n",
-       " ('X', 'Y'): {'01': 1256, '11': 1007, '10': 1217, '00': 1520},\n",
-       " ('X', 'Z'): {'01': 1228, '11': 1031, '10': 1258, '00': 1483},\n",
-       " ('Y', 'X'): {'01': 1271, '11': 1023, '10': 1222, '00': 1484},\n",
-       " ('Y', 'Y'): {'01': 2324, '11': 33, '10': 2226, '00': 417},\n",
-       " ('Y', 'Z'): {'01': 1285, '11': 1024, '10': 1196, '00': 1495},\n",
-       " ('Z', 'X'): {'01': 1313, '11': 1045, '10': 1192, '00': 1450},\n",
-       " ('Z', 'Y'): {'01': 1196, '11': 1051, '10': 1268, '00': 1485},\n",
-       " ('Z', 'Z'): {'01': 198, '11': 2054, '10': 198, '00': 2550}}"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pop1 = 0.05\n",
-    "T1 = 50\n",
-    "T2 = 2 * T1\n",
-    "t_meas = 5\n",
-    "\n",
-    "error = thermal_relaxation_error(T1, T2, t_meas, pop1)\n",
-    "\n",
-    "noise = NoiseModel()\n",
-    "noise.add_all_qubit_quantum_error(error, 'measure')\n",
-    "\n",
-    "# Generate circuits and run on simulator\n",
-    "job_cal = qiskit.execute(qst_bell, Aer.get_backend('qasm_simulator'),\n",
-    "                         shots=5000,\n",
-    "                         basis_gates=noise.basis_gates,\n",
-    "                         noise_model=noise)\n",
-    "\n",
-    "# Extract tomography data so that countns are indexed by measurement configuration\n",
-    "tomo_counts_noise = tomo.tomography_data(job_cal.result(), qst_bell)\n",
-    "tomo_counts_noise"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Create Calibration matrix\n",
-    "\n",
-    "P1_0 = pop1 * np.exp(-t_meas / T1)\n",
-    "P0_1 = (1 - pop1) * np.exp(-t_meas / T1)\n",
-    "\n",
-    "# Single qubit calibration matrix\n",
-    "cal_mat_single = np.array([[1 - P1_0, P0_1], [P1_0, 1 - P0_1]])\n",
-    "\n",
-    "# 2-qubit calibration matrix\n",
-    "cal_mat = np.kron(cal_mat_single, cal_mat_single)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0.91156309, 0.82070584, 0.82070584, 0.7389045 ],\n",
-       "       [0.04319504, 0.13405229, 0.03888971, 0.12069104],\n",
-       "       [0.04319504, 0.03888971, 0.13405229, 0.12069104],\n",
-       "       [0.00204683, 0.00635216, 0.00635216, 0.01971341]])"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cal_mat"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting without using calibration data\n",
-      "Fit Fidelity = 0.8681889118450377\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Fitting without calibration matrix\n",
-    "probs_noise, basis_matrix_noise = tomo.fitter_data(tomo_counts_noise)\n",
-    "rho_noise = tomo.state_cvx_fit(probs_noise, basis_matrix_noise)\n",
-    "print('Fitting without using calibration data')\n",
-    "print('Fit Fidelity =', state_fidelity(psi_bell, rho_noise))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using calibration data to update basis matrix\n",
-      "Fit Fidelity = 0.9788749509551824\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Fitting with calibration matrix by modifying POVMs\n",
-    "probs_noise_cal, basis_matrix_noise_cal = tomo.fitter_data(tomo_counts_noise,\n",
-    "                                                     calibration_matrix=cal_mat)\n",
-    "rho_noise_cal = tomo.state_cvx_fit(probs_noise_cal, basis_matrix_noise_cal)\n",
-    "print('Using calibration data to update basis matrix')\n",
-    "print('Fit Fidelity =', state_fidelity(psi_bell, rho_noise_cal))"
    ]
   },
   {
@@ -308,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,10 +167,10 @@
     "    job = qiskit.execute(qst_circs, Aer.get_backend('qasm_simulator'),\n",
     "                         shots=shots)\n",
     "    tomo_counts = tomo.tomography_data(job.result(), qst_circs)\n",
-    "    probs, basis_matrix = tomo.fitter_data(tomo_counts, beta=0.5)\n",
+    "    probs, basis_matrix, weights = tomo.fitter_data(tomo_counts, beta=0.5)\n",
     "    \n",
-    "    rho_cvx = tomo.state_cvx_fit(probs, basis_matrix)\n",
-    "    rho_mle = tomo.state_mle_fit(probs, basis_matrix)\n",
+    "    rho_cvx = tomo.state_cvx_fit(probs, basis_matrix, weights)\n",
+    "    rho_mle = tomo.state_mle_fit(probs, basis_matrix, weights)\n",
     "    \n",
     "    print('F fit (CVX) =', state_fidelity(psi_rand, rho_cvx))\n",
     "    print('F fit (MLE) =', state_fidelity(psi_rand, rho_mle))"
@@ -338,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -346,20 +186,20 @@
      "output_type": "stream",
      "text": [
       "Random single-qubit unitaries: set 0\n",
-      "F fit (CVX) = 0.9977859347729403\n",
-      "F fit (MLE) = 0.9976950574691672\n",
+      "F fit (CVX) = 0.9996531476657313\n",
+      "F fit (MLE) = 0.9977837664426876\n",
       "Random single-qubit unitaries: set 1\n",
-      "F fit (CVX) = 0.999495298501456\n",
-      "F fit (MLE) = 0.99750613658546\n",
+      "F fit (CVX) = 0.9980888478567496\n",
+      "F fit (MLE) = 0.9955170029643752\n",
       "Random single-qubit unitaries: set 2\n",
-      "F fit (CVX) = 0.9972536043567923\n",
-      "F fit (MLE) = 0.9984838104775382\n",
+      "F fit (CVX) = 0.9997856505320446\n",
+      "F fit (MLE) = 0.9952557042555695\n",
       "Random single-qubit unitaries: set 3\n",
-      "F fit (CVX) = 0.9984982190640335\n",
-      "F fit (MLE) = 0.9970772439464521\n",
+      "F fit (CVX) = 0.9954882353993286\n",
+      "F fit (MLE) = 0.9949071961650615\n",
       "Random single-qubit unitaries: set 4\n",
-      "F fit (CVX) = 0.9989056856839248\n",
-      "F fit (MLE) = 0.9958511474490492\n"
+      "F fit (CVX) = 0.9970772488170023\n",
+      "F fit (MLE) = 0.9940987183176082\n"
      ]
     }
    ],
@@ -378,14 +218,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time taken: 8.785384893417358\n"
+      "Time taken: 7.822285175323486\n"
      ]
     }
    ],
@@ -408,13 +248,13 @@
     "\n",
     "# Extract tomography data so that countns are indexed by measurement configuration\n",
     "tomo_counts_bell5 = tomo.tomography_data(job.result(), qst_bell5)\n",
-    "probs_bell5, basis_matrix_bell5 = tomo.fitter_data(tomo_counts_bell5)\n",
+    "probs_bell5, basis_matrix_bell5, weights_bell5 = tomo.fitter_data(tomo_counts_bell5)\n",
     "print('Time taken:', time.time() - t)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -422,14 +262,14 @@
      "output_type": "stream",
      "text": [
       "MLE Reconstruction\n",
-      "Time taken: 2.460785150527954\n",
-      "Fit Fidelity: 0.993255253328152\n"
+      "Time taken: 2.427018880844116\n",
+      "Fit Fidelity: 0.9938346924275012\n"
      ]
     }
    ],
    "source": [
     "t = time.time()\n",
-    "rho_mle_bell5 = tomo.state_mle_fit(probs_bell5, basis_matrix_bell5)\n",
+    "rho_mle_bell5 = tomo.state_mle_fit(probs_bell5, basis_matrix_bell5, weights_bell5)\n",
     "print('MLE Reconstruction')\n",
     "print('Time taken:', time.time() - t)\n",
     "print('Fit Fidelity:', state_fidelity(psi_bell5, rho_mle_bell5))"
@@ -437,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -445,14 +285,14 @@
      "output_type": "stream",
      "text": [
       "SDP Reconstruction\n",
-      "Time taken: 53.021812438964844\n",
-      "Fidelity: 0.9999274425924916\n"
+      "Time taken: 54.15808916091919\n",
+      "Fidelity: 0.9999248236498933\n"
      ]
     }
    ],
    "source": [
     "t = time.time()\n",
-    "rho_sdp_bell5 = tomo.state_cvx_fit(probs_bell5, basis_matrix_bell5, solver='CVXOPT')\n",
+    "rho_sdp_bell5 = tomo.state_cvx_fit(probs_bell5, basis_matrix_bell5, weights_bell5, solver='CVXOPT')\n",
     "print('SDP Reconstruction')\n",
     "print('Time taken:', time.time() - t)\n",
     "print('Fidelity:', state_fidelity(psi_bell5, rho_sdp_bell5))"

--- a/qiskit_ignis/tomography/README.md
+++ b/qiskit_ignis/tomography/README.md
@@ -15,7 +15,6 @@
   * Quantum state and process tomography reconstruction via semidefinite program convex optimization (SDP)
   * Helper functions for processing count data into fitter data including
     * Calculation of weights assuming Gaussian statistics
-    * Calculation of noisy measurement POVM elements using assignment fidelity calibration data
 
 ### Using
 


### PR DESCRIPTION
Updates `fitter_data` function so that it:

* remove `calibration_matrix` kwarg
* returns a tuple `probs, basis_mat, weights`
  * if `standard_weights=True`, `weights` is the binomial weights vector computed from counts
  * if `standard_weights=False` `weights` is `None` (which is valid input for fitters)
* updated example snotebooks for new fitter_data and removed calibration matrix example