### PR TITLE
changed the definition of w to hs

### DIFF
--- a/qiskit_ignis/randomized_benchmarking/standard_rb/Clifford.py
+++ b/qiskit_ignis/randomized_benchmarking/standard_rb/Clifford.py
@@ -277,8 +277,8 @@ class Clifford(object):
     def w(self, qubit):
         """Apply w gate v.v"""
         # TODO: change direct table update if more efficient
-        self.v(qubit)
-        self.v(qubit)
+        self.h(qubit)
+        self.s(qubit)
 
     def cx(self, qubit_ctrl, qubit_trgt):
         """Apply a Controlled-NOT "cx" gate"""

--- a/qiskit_ignis/randomized_benchmarking/standard_rb/clifford_utils.py
+++ b/qiskit_ignis/randomized_benchmarking/standard_rb/clifford_utils.py
@@ -382,7 +382,7 @@ def get_quantum_circuit(gatelist, num_qubits):
         if op_names == ['v']:
             op_names = ['sdg', 'h']
         elif op_names == ['w']:
-            op_names = ['sdg', 'h', 'sdg', 'h']
+            op_names = ['h', 's']
 
         qubits = [qr[int(x)] for x in split[1:]]
         for sub_op in op_names:


### PR DESCRIPTION
I changed the definition of w to hs.
Indeed, v is of order 3, and so w=vv is also the inverse of v. 
So, if v=sdg h then w=hs.
I think that this expression is better since it's shorter and have less h gates.
I checked all the tests and they are OK.