### PR TITLE
Enforce and fix lint on test code

### DIFF
--- a/tests/coherence/test_coherence.py
+++ b/tests/coherence/test_coherence.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
+# pylint: disable=no-name-in-module
+
 """
 Test coherence measurements
 """
@@ -25,7 +27,6 @@ from qiskit.ignis.characterization.coherence import t1_circuits, \
                                 t2_circuits, t2star_circuits
 
 
-
 class TestT2Star(unittest.TestCase):
     """
     Test measurement of T2*
@@ -34,14 +35,16 @@ class TestT2Star(unittest.TestCase):
     def test_t2star(self):
         """
         Run the simulator with phase damping noise.
-        Then verify that the calculated T2star matches the phase damping parameter.
+        Then verify that the calculated T2star matches the phase damping
+        parameter.
         """
 
         # Setting parameters
 
         # 25 numbers ranging from 100 to 1000, linearly spaced
-        num_of_gates = num_of_gates = np.append((np.linspace(10, 150, 30)).astype(int),
-                                                (np.linspace(160,450,20)).astype(int))
+        num_of_gates = num_of_gates = np.append(
+            (np.linspace(10, 150, 30)).astype(int),
+            (np.linspace(160, 450, 20)).astype(int))
         gate_time = 0.1
         num_of_qubits = 1
         qubit = 0
@@ -54,62 +57,57 @@ class TestT2Star(unittest.TestCase):
 
         backend = qiskit.Aer.get_backend('qasm_simulator')
         shots = 300
-
-
         # Estimating T2* via an exponential function
-
-        circs, xdata, _ = t2star_circuits(num_of_gates, gate_time, num_of_qubits, qubit)
-        backend_result = qiskit.execute(circs, backend,
-                                        shots=shots,
-                                        backend_options={'max_parallel_experiments': 0},
-                                        noise_model=noise_model).result()
+        circs, xdata, _ = t2star_circuits(num_of_gates, gate_time,
+                                          num_of_qubits, qubit)
+        backend_result = qiskit.execute(
+            circs, backend, shots=shots,
+            backend_options={'max_parallel_experiments': 0},
+            noise_model=noise_model).result()
 
         initial_t2 = expected_t2
         initial_a = 0.5
         initial_c = 0.5
 
-        fit = T2StarExpFitter(backend_result, shots, xdata, num_of_qubits, qubit,
+        fit = T2StarExpFitter(backend_result, shots, xdata, num_of_qubits,
+                              qubit,
                               fit_p0=[initial_a, initial_t2, initial_c],
-                              fit_bounds=([-0.5, 0, -0.5], [1.5, expected_t2*1.2, 1.5]))
-
-        print(fit.time)
-        print(fit.time_err)
+                              fit_bounds=([-0.5, 0, -0.5],
+                                          [1.5, expected_t2*1.2, 1.5]))
 
         self.assertAlmostEqual(fit.time, expected_t2, delta=2,
                                msg='Calculated T2 is inaccurate')
-        self.assertTrue(fit.time_err < 2,
-                        'Confidence in T2 calculation is too low: ' + str(fit.time_err))
-
-
+        self.assertTrue(
+            fit.time_err < 2,
+            'Confidence in T2 calculation is too low: ' + str(fit.time_err))
         # Estimate T2* via an oscilliator function
+        circs_osc, xdata, omega = t2star_circuits(num_of_gates, gate_time,
+                                                  num_of_qubits, qubit, 5)
 
-        circs_osc, xdata, omega = t2star_circuits(num_of_gates, gate_time, num_of_qubits, qubit, 5)
-
-        backend_result = qiskit.execute(circs_osc, backend,
-                                        shots=shots,
-                                        backend_options={'max_parallel_experiments': 0},
-                                        noise_model=noise_model).result()
+        backend_result = qiskit.execute(
+            circs_osc, backend,
+            shots=shots,
+            backend_options={'max_parallel_experiments': 0},
+            noise_model=noise_model).result()
 
         initial_a = 0.5
         initial_c = 0.5
         initial_f = omega
         initial_phi = 0
-
-        fit = T2StarOscFitter(backend_result, shots, xdata, num_of_qubits, qubit,
-                              fit_p0=[initial_a, initial_t2, initial_f, initial_phi, initial_c],
+        fit = T2StarOscFitter(backend_result, shots, xdata, num_of_qubits,
+                              qubit,
+                              fit_p0=[initial_a, initial_t2, initial_f,
+                                      initial_phi, initial_c],
                               fit_bounds=([-0.5, 0, omega-0.02, -np.pi, -0.5],
-                                          [1.5, expected_t2*1.2, omega+0.02, np.pi, 1.5]))
-
-        print(fit.time)
-        print(fit.time_err)
-
+                                          [1.5, expected_t2*1.2, omega+0.02,
+                                           np.pi, 1.5]))
         self.assertAlmostEqual(fit.time, expected_t2, delta=2,
                                msg='Calculated T2 is inaccurate')
-        self.assertTrue(fit.time_err < 2,
-                        'Confidence in T2 calculation is too low: ' + str(fit.time_err))
-
-
+        self.assertTrue(
+            fit.time_err < 2,
+            'Confidence in T2 calculation is too low: ' + str(fit.time_err))
         # TODO: add SPAM
+
 
 class TestT1(unittest.TestCase):
     """
@@ -119,7 +117,8 @@ class TestT1(unittest.TestCase):
     def test_t1(self):
         """
         Run the simulator with amplitude damping noise.
-        Then verify that the calculated T1 matches the amplitude damping parameter.
+        Then verify that the calculated T1 matches the amplitude damping
+        parameter.
         """
 
         # 25 numbers ranging from 1 to 200, linearly spaced
@@ -128,7 +127,8 @@ class TestT1(unittest.TestCase):
         num_of_qubits = 2
         qubit = 0
 
-        circs, xdata = t1_circuits(num_of_gates, gate_time, num_of_qubits, qubit)
+        circs, xdata = t1_circuits(num_of_gates, gate_time, num_of_qubits,
+                                   qubit)
 
         expected_t1 = 10
         gamma = 1 - np.exp(-gate_time/expected_t1)
@@ -139,26 +139,25 @@ class TestT1(unittest.TestCase):
 
         backend = qiskit.Aer.get_backend('qasm_simulator')
         shots = 300
-        backend_result = qiskit.execute(circs, backend,
-                                        shots=shots,
-                                        backend_options={'max_parallel_experiments': 0},
-                                        noise_model=noise_model).result()
+        backend_result = qiskit.execute(
+            circs, backend,
+            shots=shots,
+            backend_options={'max_parallel_experiments': 0},
+            noise_model=noise_model).result()
 
         initial_t1 = expected_t1
         initial_a = 1
         initial_c = 0
-
         fit = T1Fitter(backend_result, shots, xdata, num_of_qubits, qubit,
                        fit_p0=[initial_a, initial_t1, initial_c],
                        fit_bounds=([0, 0, -1], [2, expected_t1*1.2, 1]))
 
-        print(fit.time)
-        print(fit.time_err)
-
         self.assertAlmostEqual(fit.time, expected_t1, delta=20,
                                msg='Calculated T1 is inaccurate')
-        self.assertTrue(fit.time_err < 30,
-                        'Confidence in T1 calculation is too low: ' + str(fit.time_err))
+        self.assertTrue(
+            fit.time_err < 30,
+            'Confidence in T1 calculation is too low: ' + str(fit.time_err))
+
 
 class TestT2(unittest.TestCase):
     """
@@ -177,7 +176,8 @@ class TestT2(unittest.TestCase):
         num_of_qubits = 2
         qubit = 0
 
-        circs, xdata = t2_circuits(num_of_gates, gate_time, num_of_qubits, qubit)
+        circs, xdata = t2_circuits(num_of_gates, gate_time, num_of_qubits,
+                                   qubit)
 
         expected_t2 = 20
         gamma = 1 - np.exp(-2*gate_time/expected_t2)
@@ -188,10 +188,11 @@ class TestT2(unittest.TestCase):
 
         backend = qiskit.Aer.get_backend('qasm_simulator')
         shots = 300
-        backend_result = qiskit.execute(circs, backend,
-                                        shots=shots,
-                                        backend_options={'max_parallel_experiments': 0},
-                                        noise_model=noise_model).result()
+        backend_result = qiskit.execute(
+            circs, backend,
+            shots=shots,
+            backend_options={'max_parallel_experiments': 0},
+            noise_model=noise_model).result()
 
         initial_t2 = expected_t2
         initial_a = 1
@@ -201,14 +202,11 @@ class TestT2(unittest.TestCase):
                        fit_p0=[initial_a, initial_t2, initial_c],
                        fit_bounds=([0, 0, -1], [2, expected_t2*1.2, 1]))
 
-        print(fit.time)
-        print(fit.time_err)
-
         self.assertAlmostEqual(fit.time, expected_t2, delta=4,
                                msg='Calculated T2 is inaccurate')
-        self.assertTrue(fit.time_err < 5,
-                        'Confidence in T2 calculation is too low: ' + str(fit.time_err))
-
+        self.assertTrue(
+            fit.time_err < 5,
+            'Confidence in T2 calculation is too low: ' + str(fit.time_err))
 
 
 if __name__ == '__main__':

--- a/tests/rb/test_clifford.py
+++ b/tests/rb/test_clifford.py
@@ -7,8 +7,10 @@
 
 """
 Test Clifford functions:
-- Generating Clifford tables on 1 and 2 qubits: clifford_utils.clifford1_table and clifford_utils.clifford2_table
-- Generating a pseudo-random Clifford (using the tables): clifford_utils.random_clifford
+- Generating Clifford tables on 1 and 2 qubits: clifford_utils.clifford1_table
+  and clifford_utils.clifford2_table
+- Generating a pseudo-random Clifford (using the tables):
+  clifford_utils.random_clifford
 - Inverting a Clifford: clifford_utils.find_inverse_clifford_circuit
 """
 
@@ -20,7 +22,8 @@ import tempfile
 import numpy as np
 
 # Import the clifford_utils functions
-from  qiskit.ignis.randomized_benchmarking import clifford_utils as clutils
+from qiskit.ignis.randomized_benchmarking import clifford_utils as clutils
+
 
 class TestClifford(unittest.TestCase):
     """
@@ -62,7 +65,7 @@ class TestClifford(unittest.TestCase):
             'test_tables_expected.txt')
         self.assertTrue(
             filecmp.cmp(test_tables_file_path, expected_file_path),
-                        "Error: tables on 1 and 2 qubits are not the same")
+            "Error: tables on 1 and 2 qubits are not the same")
 
     def test_random_and_inverse(self):
         """
@@ -76,24 +79,24 @@ class TestClifford(unittest.TestCase):
         self.addCleanup(os.remove, test_random_file_path)
         with os.fdopen(test_random_fd, mode='w') as test_random_file:
 
-            # test: generating a pseudo-random Clifford using tables - 1&2 qubits
-            # and computing its inverse
+            # test: generating a pseudo-random Clifford using tables -
+            # 1&2 qubits and computing its inverse
             for nq in range(1, 1+self.max_nq):
                 for i in range(0, self.number_of_tests):
                     my_seed = i
                     np.random.seed(my_seed)
                     random.seed(my_seed)
                     test_random_file.write(
-                        "test: generating a pseudo-random clifford using the tables "
-                        "- %d qubit - seed=%d:\n" %(nq, my_seed))
+                        "test: generating a pseudo-random clifford using the "
+                        "tables - %d qubit - seed=%d:\n" % (nq, my_seed))
                     cliff_nq = clutils.random_clifford_gates(nq)
                     test_random_file.write(str(cliff_nq))
                     test_random_file.write("\n")
                     test_random_file.write(
-                        "test: inverting a pseudo-random clifford using the tables "
-                        "- %d qubit - seed=%d:\n" %(nq, my_seed))
-                    inv_cliff_nq = clutils.find_inverse_clifford_gates(nq,cliff_nq)
-
+                        "test: inverting a pseudo-random clifford using the "
+                        "tables - %d qubit - seed=%d:\n" % (nq, my_seed))
+                    inv_cliff_nq = clutils.find_inverse_clifford_gates(
+                        nq, cliff_nq)
                     test_random_file.write(str(inv_cliff_nq))
                     test_random_file.write("\n")
                     test_random_file.write(
@@ -105,7 +108,7 @@ class TestClifford(unittest.TestCase):
             'test_random_expected.txt')
         self.assertTrue(
             filecmp.cmp(test_random_file_path, expected_file_path),
-                        "Error: random and/or inverse cliffords are not the same")
+            "Error: random and/or inverse cliffords are not the same")
 
 
 if __name__ == '__main__':

--- a/tests/rb/test_fitters.py
+++ b/tests/rb/test_fitters.py
@@ -10,8 +10,11 @@ Test the fitters
 """
 
 import os
+import pickle
 import unittest
+
 import numpy as np
+
 from qiskit.ignis.randomized_benchmarking import RBFitter
 
 
@@ -21,100 +24,128 @@ class TestFitters(unittest.TestCase):
     def test_fitters(self):
         """ Test the fitters """
 
-        #Use pickled results files
+        # Use pickled results files
 
-        tests = [
-            {'rb_opts':
-                 {'xdata': np.array([[1,  21,  41,  61,  81, 101, 121, 141, 161, 181],
-                                     [2,  42,  82, 122, 162, 202, 242, 282, 322, 362]]),
-                  'rb_pattern': [[0,1], [2]],
-                  'shots': 1024
-                  },
-             'results_file': os.path.join(os.path.dirname(__file__),
-                                          'test_fitter_results_1.pkl'),
-             'expected':
-                 {'ydata': [{'mean': np.array([0.96367187, 0.73457031,
-                                               0.58066406, 0.4828125 , 0.41035156,
-                                      0.34902344, 0.31210938, 0.2765625 , 0.29453125, 0.27695313]),
-                  'std': np.array([0.01013745, 0.0060955 , 0.00678272, 0.01746491, 0.02015981,
-                         0.02184184, 0.02340167, 0.02360293, 0.00874773, 0.01308156])},
-                 {'mean': np.array([0.98925781, 0.87734375, 0.78125   , 0.73066406, 0.68496094,
-                         0.64296875, 0.59238281, 0.57421875, 0.56074219, 0.54980469]),
-                  'std': np.array([0.00276214, 0.01602991, 0.00768946, 0.01413015, 0.00820777,
-                         0.01441348, 0.01272682, 0.01031649, 0.02103036, 0.01224408])}],
-                  'fit': [{'params': np.array([0.71936804, 0.98062119, 0.25803749]),
-                          'params_err': np.array([0.0065886 , 0.00046714, 0.00556488]),
-                          'epc': 0.014534104912075935,
-                          'epc_err': 6.923601336318206e-06},
-                         {'params': np.array([0.49507094, 0.99354093, 0.50027262]),
-                          'params_err': np.array([0.0146191 , 0.0004157 , 0.01487439]),
-                          'epc': 0.0032295343343508587,
-                          'epc_err': 1.3512528169626024e-06}]
-                  }
-             },
-            {'rb_opts':
-                 {'xdata': np.array([[  1,  21,  41,  61,  81, 101, 121, 141, 161, 181]]),
-                  'rb_pattern': [[0]],
-                  'shots': 1024
-                  },
-             'results_file': os.path.join(os.path.dirname(__file__),
-                                          'test_fitter_results_2.pkl'),
-             'expected':
-                 {'ydata': [{'mean': np.array([0.99199219, 0.93867188,
-                                            0.87871094, 0.83945313, 0.79335937,
-                                 0.74785156, 0.73613281, 0.69414062, 0.67460937, 0.65664062]),
-                          'std': np.array([0.00567416, 0.00791919, 0.01523437,
-                                        0.01462368, 0.01189002,
-                                 0.01445049, 0.00292317, 0.00317345, 0.00406888, 0.01504794])}],
-                  'fit': [{'params': np.array([0.59599995, 0.99518211, 0.39866989]),
-                              'params_err': np.array([0.08843152, 0.00107311, 0.09074325]),
-                              'epc': 0.0024089464034862673,
-                              'epc_err': 2.5975709525210163e-06}]
-                  }
-             }
-        ]
+        tests = [{
+            'rb_opts': {
+                'xdata': np.array([[1, 21, 41, 61, 81, 101, 121, 141,
+                                    161, 181],
+                                   [2, 42, 82, 122, 162, 202, 242, 282,
+                                    322, 362]]),
+                'rb_pattern': [[0, 1], [2]],
+                'shots': 1024},
+            'results_file': os.path.join(os.path.dirname(__file__),
+                                         'test_fitter_results_1.pkl'),
+            'expected': {
+                'ydata': [{
+                    'mean': np.array([0.96367187, 0.73457031,
+                                      0.58066406, 0.4828125,
+                                      0.41035156, 0.34902344,
+                                      0.31210938, 0.2765625,
+                                      0.29453125, 0.27695313]),
+                    'std': np.array([0.01013745, 0.0060955, 0.00678272,
+                                     0.01746491, 0.02015981, 0.02184184,
+                                     0.02340167, 0.02360293, 0.00874773,
+                                     0.01308156])}, {
+                                         'mean': np.array([0.98925781,
+                                                           0.87734375, 0.78125,
+                                                           0.73066406,
+                                                           0.68496094,
+                                                           0.64296875,
+                                                           0.59238281,
+                                                           0.57421875,
+                                                           0.56074219,
+                                                           0.54980469]),
+                                         'std': np.array(
+                                             [0.00276214, 0.01602991,
+                                              0.00768946, 0.01413015,
+                                              0.00820777, 0.01441348,
+                                              0.01272682, 0.01031649,
+                                              0.02103036, 0.01224408])}],
+                'fit': [{
+                    'params': np.array([0.71936804, 0.98062119,
+                                        0.25803749]),
+                    'params_err': np.array([0.0065886, 0.00046714,
+                                            0.00556488]),
+                    'epc': 0.014534104912075935,
+                    'epc_err': 6.923601336318206e-06},
+                        {'params': np.array([0.49507094, 0.99354093,
+                                             0.50027262]),
+                         'params_err': np.array([0.0146191, 0.0004157,
+                                                 0.01487439]),
+                         'epc': 0.0032295343343508587,
+                         'epc_err': 1.3512528169626024e-06}]
+            }}, {
+                'rb_opts': {
+                    'xdata': np.array([[1, 21, 41, 61, 81, 101, 121, 141, 161,
+                                        181]]),
+                    'rb_pattern': [[0]],
+                    'shots': 1024},
+                'results_file': os.path.join(os.path.dirname(__file__),
+                                             'test_fitter_results_2.pkl'),
+                'expected': {
+                    'ydata': [{'mean': np.array([0.99199219, 0.93867188,
+                                                 0.87871094, 0.83945313,
+                                                 0.79335937, 0.74785156,
+                                                 0.73613281, 0.69414062,
+                                                 0.67460937, 0.65664062]),
+                               'std': np.array([0.00567416, 0.00791919,
+                                                0.01523437, 0.01462368,
+                                                0.01189002, 0.01445049,
+                                                0.00292317, 0.00317345,
+                                                0.00406888,
+                                                0.01504794])}],
+                    'fit': [{'params': np.array([0.59599995, 0.99518211,
+                                                 0.39866989]),
+                             'params_err': np.array([0.08843152, 0.00107311,
+                                                     0.09074325]),
+                             'epc': 0.0024089464034862673,
+                             'epc_err': 2.5975709525210163e-06}]}}]
 
         for tst_index, tst in enumerate(tests):
-
-            import pickle
-
-            fo = open(tst['results_file'],'rb')
+            fo = open(tst['results_file'], 'rb')
             results_list = pickle.load(fo)
             fo.close()
 
             # RBFitter class
             rb_fit = RBFitter(results_list, tst['rb_opts']['xdata'],
-                              tst['rb_opts']['shots'], tst['rb_opts']['rb_pattern'])
-
-
+                              tst['rb_opts']['shots'],
+                              tst['rb_opts']['rb_pattern'])
             ydata = rb_fit.ydata
             fit = rb_fit.fit
 
-            for i,_ in enumerate(ydata):
+            for i, _ in enumerate(ydata):
                 self.assertTrue(all(np.isclose(a, b) for a, b in
-                                    zip(ydata[i]['mean'], tst['expected']['ydata'][i]['mean'])),
+                                    zip(ydata[i]['mean'],
+                                        tst['expected']['ydata'][i]['mean'])),
                                 'Incorrect mean in test no. ' + str(tst_index))
                 if tst['expected']['ydata'][i]['std'] is None:
-                    self.assertIsNone(ydata[i]['std'],
-                                      'Incorrect std in test no. ' + str(tst_index))
+                    self.assertIsNone(
+                        ydata[i]['std'],
+                        'Incorrect std in test no. ' + str(tst_index))
                 else:
-                    self.assertTrue(all(np.isclose(a, b) for a, b in
-                                        zip(ydata[i]['std'], tst['expected']['ydata'][i]['std'])),
-                                    'Incorrect std in test no. ' + str(tst_index))
-
-
-                self.assertTrue(all(np.isclose(a, b) for a, b in
-                                    zip(fit[i]['params'], tst['expected']['fit'][i]['params'])),
-                                'Incorrect fit parameters in test no. ' + str(tst_index))
-                self.assertTrue(all(np.isclose(a, b) for a, b in
-                                    zip(fit[i]['params_err'],
-                                        tst['expected']['fit'][i]['params_err'])),
-                                'Incorrect fit error in test no. ' + str(tst_index))
-                self.assertTrue(np.isclose(fit[i]['epc'], tst['expected']['fit'][i]['epc']),
+                    self.assertTrue(
+                        all(np.isclose(a, b) for a, b in zip(
+                            ydata[i]['std'],
+                            tst['expected']['ydata'][i]['std'])),
+                        'Incorrect std in test no. ' + str(tst_index))
+                self.assertTrue(
+                    all(np.isclose(a, b) for a, b in zip(
+                        fit[i]['params'],
+                        tst['expected']['fit'][i]['params'])),
+                    'Incorrect fit parameters in test no. ' + str(tst_index))
+                self.assertTrue(
+                    all(np.isclose(a, b) for a, b in zip(
+                        fit[i]['params_err'],
+                        tst['expected']['fit'][i]['params_err'])),
+                    'Incorrect fit error in test no. ' + str(tst_index))
+                self.assertTrue(np.isclose(fit[i]['epc'],
+                                           tst['expected']['fit'][i]['epc']),
                                 'Incorrect EPC in test no. ' + str(tst_index))
-                self.assertTrue(np.isclose(fit[i]['epc_err'],
-                                           tst['expected']['fit'][i]['epc_err']),
-                                'Incorrect EPC error in test no. ' + str(tst_index))
+                self.assertTrue(
+                    np.isclose(fit[i]['epc_err'],
+                               tst['expected']['fit'][i]['epc_err']),
+                    'Incorrect EPC error in test no. ' + str(tst_index))
 
 
 if __name__ == '__main__':

--- a/tests/rb/test_rb.py
+++ b/tests/rb/test_rb.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
+# pylint: disable=undefined-loop-variable
+
 """
 Run through RB for different qubit numbers to check that it's working
 and that it returns the identity
@@ -15,28 +17,31 @@ import random
 import qiskit
 import qiskit.ignis.randomized_benchmarking as rb
 
+
 class TestRB(unittest.TestCase):
     """ The test class """
-
 
     @staticmethod
     def choose_pattern(pattern_type, nq):
         '''
         Choose a valid field for rb_opts['rb_pattern']
         :param pattern_type: a number between 0 and 2.
-                             0 - a list of all qubits, for nq=5 it is [1, 2, 3, 4, 5]
+                             0 - a list of all qubits, for nq=5 it is
+                                 [1, 2, 3, 4, 5]
                              1 - a list of lists of single qubits, for nq=5
                                  it is [[1], [2], [3], [4], [5]]
-                             2 - randomly choose a pattern which is a list of two lists,
-                                for example for nq=5 it can be [[4, 1, 2], [5, 3]]
+                             2 - randomly choose a pattern which is a list of
+                                 two lists, for example for nq=5 it can be
+                                 [[4, 1, 2], [5, 3]]
         :param nq: number of qubits
         :return: the pattern or None
-                 Returns None if the pattern type is not relevant to the number of qubits,
-                 i.e,, one of two cases:
+                 Returns None if the pattern type is not relevant to the
+                 number of qubits, i.e,, one of two cases:
                  pattern_type = 1 and nq = 1, which implies [[1]]
                  pattern_type = 2 and nq <= 2: - for nq=1 this is impossible
-                                               - for nq=2 this implies [[1], [2]],
-                                                 which is already tested when pattern_type = 1
+                                               - for nq=2 this implies
+                                                 [[1], [2]], which is already
+                                                 tested when pattern_type = 1
         '''
 
         if pattern_type == 0:
@@ -56,7 +61,7 @@ class TestRB(unittest.TestCase):
         return res
 
     @staticmethod
-    def choose_multiplier(mult_opt,len_pattern):
+    def choose_multiplier(mult_opt, len_pattern):
         '''
         :param multi_opt:
             0: fixed length
@@ -64,10 +69,10 @@ class TestRB(unittest.TestCase):
         :param len_pattern: number of patterns
         :return: the length multiplier
         '''
-        if mult_opt==0:
+        if mult_opt == 0:
             res = 1
         else:
-            res = [i+1 for i in range(len_pattern)]
+            res = [i + 1 for i in range(len_pattern)]
 
         return res
 
@@ -76,36 +81,45 @@ class TestRB(unittest.TestCase):
         For a single sequence, verifies that it meets the requirements:
         - Executing it on the ground state ends up in the ground state
         - It has the correct number of Cliffords
-        - It fulfills the pattern, as specified by rb_patterns and length_multiplier
+        - It fulfills the pattern, as specified by rb_patterns and
+          length_multiplier
         :param circ: the sequence to check
         :param nq: number of qubits
-        :param rb_opts: the specification that generated the set of sequences which includes circ
-        :param vec_len: the expected length vector of circ (one of rb_opts['length_vector']
+        :param rb_opts: the specification that generated the set of sequences
+                        which includes circ
+        :param vec_len: the expected length vector of circ (one of
+                        rb_opts['length_vector'])
         :param result: the output of the simulator
                        when executing all the sequences on the ground state
         :param shots: the number of shots in the simulator execution
         '''
 
         if not hasattr(rb_opts['length_multiplier'], "__len__"):
-            rb_opts['length_multiplier'] = [rb_opts['length_multiplier'] for
-                    i in range(len(rb_opts['rb_pattern']))]
+            rb_opts['length_multiplier'] = [
+                rb_opts['length_multiplier'] for i in range(
+                    len(rb_opts['rb_pattern']))]
 
         ops = circ.data
         op_index = 0
-        for _ in range(vec_len):   # for each cycle (the sequence should consist of vec_len cycles)
+        # for each cycle (the sequence should consist of vec_len cycles)
+        for _ in range(vec_len):
+            # for each component of the pattern...
             for pat_index in range(len(rb_opts['rb_pattern'])):
-                # for each component of the pattern...
-                for _ in range(rb_opts['length_multiplier'][pat_index]):  # for each Clifford...
-                    while ops[op_index].name != 'barrier':  # for each basis gate...
+                # for each Clifford...
+                for _ in range(rb_opts['length_multiplier'][pat_index]):
+                    # for each basis gate...
+                    while ops[op_index].name != 'barrier':
                         # Verify that the gate acts on the correct qubits
-                        # This happens if the sequence is composed of the correct sub-sequences,
-                        # as specified by vec_len and rb_opts
-                        self.assertTrue(all(x[1] in rb_opts['rb_pattern'][pat_index] \
-                                            for x in ops[op_index].qargs),
-                                        "Error: operation acts on incorrect qubits")
+                        # This happens if the sequence is composed of the
+                        # correct sub-sequences, as specified by vec_len and
+                        # rb_opts
+                        self.assertTrue(
+                            all(x[1] in rb_opts['rb_pattern'][pat_index]
+                                for x in ops[op_index].qargs),
+                            "Error: operation acts on incorrect qubits")
                         op_index += 1
-                    op_index += 1  # increment because of the barrier gate
-
+                    # increment because of the barrier gate
+                    op_index += 1
         # check if the ground state returns
         self.assertEqual(result.
                          get_counts(circ)['{0:b}'.format(0).zfill(nq)], shots,
@@ -123,47 +137,61 @@ class TestRB(unittest.TestCase):
 
         for nq in nq_list:
 
-            print("Testing %d qubit RB"%nq)
+            print("Testing %d qubit RB" % nq)
 
             for pattern_type in range(2):
                 for multiplier_type in range(2):
-                    # See documentation of choose_pattern for the meaning of the different pattern types
+                    # See documentation of choose_pattern for the meaning of
+                    # the different pattern types
 
                     rb_opts = {}
                     rb_opts['nseeds'] = 3
-                    rb_opts['length_vector'] = [1,3,4,7]
-                    rb_opts['rb_pattern'] = self.choose_pattern(pattern_type, nq)
-                    if rb_opts['rb_pattern'] is None:   # if the pattern type is not relevant for nq
+                    rb_opts['length_vector'] = [1, 3, 4, 7]
+                    rb_opts['rb_pattern'] = self.choose_pattern(
+                        pattern_type, nq)
+                    # if the pattern type is not relevant for nq
+                    if rb_opts['rb_pattern'] is None:
                         continue
-                    rb_opts['length_multiplier'] = \
-                    self.choose_multiplier(multiplier_type, len(rb_opts['rb_pattern']))
+                    rb_opts['length_multiplier'] = self.choose_multiplier(
+                        multiplier_type, len(rb_opts['rb_pattern']))
 
                     # Generate the sequences
                     try:
                         rb_circs, _ = rb.randomized_benchmarking_seq(**rb_opts)
                     except OSError:
-                        print('Skipping tests for ' + str(nq) + ' qubits because tables are missing')
+                        skip_msg = ('Skipping tests for %s qubits because '
+                                    'tables are missing' % str(nq))
+                        print(skip_msg)
                         continue
 
                     # Perform an ideal execution on the generated sequences
-                    #basis_gates = ['u1','u2','u3','cx'] # use U, CX for now
-                    basis_gates = 'u1, u2, u3, cx' # Shelly: changed format to fit qiskit current version
+                    # basis_gates = ['u1','u2','u3','cx'] # use U, CX for now
+                    # Shelly: changed format to fit qiskit current version
+                    basis_gates = 'u1, u2, u3, cx'
                     shots = 100
                     result = []
                     for seed in range(rb_opts['nseeds']):
-                        result.append(qiskit.execute(rb_circs[seed], backend=backend,
-                                                basis_gates=basis_gates, shots=shots).result())
+                        result.append(
+                            qiskit.execute(rb_circs[seed], backend=backend,
+                                           basis_gates=basis_gates,
+                                           shots=shots).result())
 
                     # Verify the generated sequences
                     for seed in range(rb_opts['nseeds']):
-                        for circ_index,vec_len in enumerate(rb_opts['length_vector']):
-                            self.assertEqual(rb_circs[seed][circ_index].name,
-                                             'rb_seed_' + str(seed) + '_length_' + str(vec_len),
-                                             'Error: incorrect circuit name')
-                            self.verify_circuit(rb_circs[seed][circ_index], nq, rb_opts,
+                        length_vec = rb_opts['length_vector']
+                        for circ_index, vec_len in enumerate(length_vec):
+
+                            self.assertEqual(
+                                rb_circs[seed][circ_index].name,
+                                'rb_seed_%s_length_%s' % (
+                                    str(seed), str(vec_len)),
+                                'Error: incorrect circuit name')
+                            self.verify_circuit(rb_circs[seed][circ_index],
+                                                nq, rb_opts,
                                                 vec_len, result[seed], shots)
 
-                    self.assertEqual(circ_index, len(rb_circs), "Error: additional circuits exist")
+                    self.assertEqual(circ_index, len(rb_circs),
+                                     "Error: additional circuits exist")
 
 
 if __name__ == '__main__':

--- a/tests/tomography/test_fitters.py
+++ b/tests/tomography/test_fitters.py
@@ -1,17 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=missing-docstring
+
 import collections
 import unittest
-import qiskit.ignis.tomography.fitters as fitters
+
 import numpy
 
+import qiskit.ignis.tomography.fitters as fitters
+
+
 class TestFitters(unittest.TestCase):
-    def assertMatricesAlmostEqual(self, lhs, rhs, places = None):
-        self.assertEqual(lhs.shape, rhs.shape, "Marix shapes differ: {} vs {}".format(lhs, rhs))
+    def assertMatricesAlmostEqual(self, lhs, rhs, places=None):
+        self.assertEqual(lhs.shape, rhs.shape,
+                         "Marix shapes differ: {} vs {}".format(lhs, rhs))
         n, m = lhs.shape
         for x in range(n):
             for y in range(m):
-                self.assertAlmostEqual(lhs[x,y], rhs[x,y], places = places, msg="Matrices {} and {} differ on ({}, {})".format(lhs, rhs, x, y))
-
-    A = numpy.array([# the basis matrix for 1-qubit measurement in the Pauli basis
+                self.assertAlmostEqual(
+                    lhs[x, y], rhs[x, y], places=places,
+                    msg="Matrices {} and {} differ on ({}, {})".format(
+                        lhs, rhs, x, y))
+    # the basis matrix for 1-qubit measurement in the Pauli basis
+    A = numpy.array([
         [0.5 + 0.j, 0.5 + 0.j, 0.5 + 0.j, 0.5 + 0.j],
         [0.5 + 0.j, -0.5 + 0.j, -0.5 + 0.j, 0.5 + 0.j],
         [0.5 + 0.j, 0. - 0.5j, 0. + 0.5j, 0.5 + 0.j],
@@ -24,18 +40,18 @@ class TestFitters(unittest.TestCase):
         p = numpy.array([1/2, 1/2, 1/2, 1/2, 1/2, 1/2])
 
         for trace_value in [1, 0.3, 2, 0, 42]:
-            rho = fitters.cvx_fit(p, self.A, trace = trace_value)
-            self.assertAlmostEqual(numpy.trace(rho), trace_value, places = 3)
+            rho = fitters.cvx_fit(p, self.A, trace=trace_value)
+            self.assertAlmostEqual(numpy.trace(rho), trace_value, places=3)
 
     def test_fitter_data(self):
         data = collections.OrderedDict()
         data[('X',)] = {'0': 5000}
         data[('Y',)] = {'0': 2508, '1': 2492}
         data[('Z',)] = {'0': 2490, '1': 2510}
-        p, A, weights = fitters.fitter_data(data)
+        p, A, _ = fitters.fitter_data(data)
         self.assertMatricesAlmostEqual(self.A, A)
         n = 5000
-        expected_p = [5000 / n, 0 / n, 2508 / n, 2492 / n, 2490 /n, 2510 / n]
+        expected_p = [5000 / n, 0 / n, 2508 / n, 2492 / n, 2490 / n, 2510 / n]
         self.assertListEqual(expected_p, p)
 
 

--- a/tests/tomography/test_pauli_basis.py
+++ b/tests/tomography/test_pauli_basis.py
@@ -1,19 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=missing-docstring
+
 import unittest
-import qiskit.ignis.tomography.basis.paulibasis as paulibasis
+
 import numpy
 
+import qiskit.ignis.tomography.basis.paulibasis as paulibasis
+
+
 class TestPauliBasis(unittest.TestCase):
-    X = numpy.array([[0,1],[1,0]])
+    X = numpy.array([[0, 1], [1, 0]])
     Y = numpy.array([[0, -1j], [1j, 0]])
     Z = numpy.array([[1, 0], [0, -1]])
 
-    def assertMatricesAlmostEqual(self, lhs, rhs, places = None):
-        self.assertEqual(lhs.shape, rhs.shape, "Marix shapes differ: {} vs {}".format(lhs, rhs))
+    def assertMatricesAlmostEqual(self, lhs, rhs, places=None):
+        self.assertEqual(lhs.shape, rhs.shape,
+                         "Marix shapes differ: {} vs {}".format(lhs, rhs))
         n, m = lhs.shape
         for x in range(n):
             for y in range(m):
-                self.assertAlmostEqual(lhs[x,y], rhs[x,y], places = places, msg="Matrices {} and {} differ on ({}, {})".format(lhs, rhs, x, y))
-
+                self.assertAlmostEqual(
+                    lhs[x, y], rhs[x, y], places=places,
+                    msg="Matrices {} and {} differ on ({}, {})".format(
+                        lhs, rhs, x, y))
 
     def test_measurement_matrices(self):
         X0 = paulibasis.pauli_measurement_matrix("X", 0)

--- a/tests/tomography/test_state_tomography.py
+++ b/tests/tomography/test_state_tomography.py
@@ -1,21 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=missing-docstring
+
 import unittest
-from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister, Aer
-from qiskit.quantum_info import state_fidelity
-import qiskit.ignis.tomography as tomo
-import qiskit
+
 import numpy
+import qiskit
+from qiskit import QuantumRegister, QuantumCircuit, Aer
+from qiskit.quantum_info import state_fidelity
+
+import qiskit.ignis.tomography as tomo
+
+
+def run_circuit_and_tomography(circuit, qubits):
+    job = qiskit.execute(circuit, Aer.get_backend('statevector_simulator'))
+    psi = job.result().get_statevector(circuit)
+    qst = tomo.state_tomography_circuits(circuit, qubits)
+    job = qiskit.execute(qst, Aer.get_backend('qasm_simulator'),
+                         shots=5000)
+    tomo_counts = tomo.tomography_data(job.result(), qst)
+    probs, basis_matrix, _ = tomo.fitter_data(tomo_counts)
+    rho_cvx = tomo.state_cvx_fit(probs, basis_matrix)
+    rho_mle = tomo.state_mle_fit(probs, basis_matrix)
+    return (rho_cvx, rho_mle, psi)
+
 
 class TestStateTomography(unittest.TestCase):
-    def run_circuit_and_tomography(self, circuit, qubits):
-        job = qiskit.execute(circuit, Aer.get_backend('statevector_simulator'))
-        psi = job.result().get_statevector(circuit)
-        qst = tomo.state_tomography_circuits(circuit, qubits)
-        job = qiskit.execute(qst, Aer.get_backend('qasm_simulator'), shots=5000)
-        tomo_counts = tomo.tomography_data(job.result(), qst)
-        probs, basis_matrix, weights = tomo.fitter_data(tomo_counts)
-        rho_cvx = tomo.state_cvx_fit(probs, basis_matrix)
-        rho_mle = tomo.state_mle_fit(probs, basis_matrix)
-        return (rho_cvx, rho_mle, psi)
 
     def test_bell_2_qubits(self):
         q2 = QuantumRegister(2)
@@ -23,9 +38,9 @@ class TestStateTomography(unittest.TestCase):
         bell.h(q2[0])
         bell.cx(q2[0], q2[1])
 
-        rho_cvx, rho_mle, psi = self.run_circuit_and_tomography(bell, q2)
+        rho_cvx, rho_mle, psi = run_circuit_and_tomography(bell, q2)
         F_bell_cvx = state_fidelity(psi, rho_cvx)
-        self.assertAlmostEqual(F_bell_cvx, 1, places = 1)
+        self.assertAlmostEqual(F_bell_cvx, 1, places=1)
         F_bell_mle = state_fidelity(psi, rho_mle)
         self.assertAlmostEqual(F_bell_mle, 1, places=1)
 
@@ -36,7 +51,7 @@ class TestStateTomography(unittest.TestCase):
         bell.cx(q3[0], q3[1])
         bell.cx(q3[1], q3[2])
 
-        rho_cvx, rho_mle, psi = self.run_circuit_and_tomography(bell, q3)
+        rho_cvx, rho_mle, psi = run_circuit_and_tomography(bell, q3)
         F_bell_cvx = state_fidelity(psi, rho_cvx)
         self.assertAlmostEqual(F_bell_cvx, 1, places=1)
         F_bell_mle = state_fidelity(psi, rho_mle)
@@ -47,7 +62,7 @@ class TestStateTomography(unittest.TestCase):
         circ = QuantumCircuit(q)
         circ.u3(1, 1, 1, q[0])
 
-        rho_cvx, rho_mle, psi = self.run_circuit_and_tomography(circ, q)
+        rho_cvx, rho_mle, psi = run_circuit_and_tomography(circ, q)
         F_bell_cvx = state_fidelity(psi, rho_cvx)
         self.assertAlmostEqual(F_bell_cvx, 1, places=1)
         F_bell_mle = state_fidelity(psi, rho_mle)
@@ -62,11 +77,12 @@ class TestStateTomography(unittest.TestCase):
         for j in range(3):
             circ.u3(*rand_angles(), q[j])
 
-        rho_cvx, rho_mle, psi = self.run_circuit_and_tomography(circ, q)
+        rho_cvx, rho_mle, psi = run_circuit_and_tomography(circ, q)
         F_bell_cvx = state_fidelity(psi, rho_cvx)
         self.assertAlmostEqual(F_bell_cvx, 1, places=1)
         F_bell_mle = state_fidelity(psi, rho_mle)
         self.assertAlmostEqual(F_bell_mle, 1, places=1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -20,5 +20,5 @@ deps =
   pycodestyle
   pylint
 commands =
-  pycodestyle qiskit/ignis
-  pylint -rn --rcfile={toxinidir}/.pylintrc qiskit/ignis
+  pycodestyle qiskit/ignis tests/
+  pylint -rn --rcfile={toxinidir}/.pylintrc qiskit/ignis tests/


### PR DESCRIPTION
We are currently only enforcing the lint and style checkers on the main
project code and ignoring the test code. We really should ensure a
consistent style throughout the entire repo if we're going to do it at
all. This commit does just that and adds lint enforcement for the tests.
In order to make this work it also fixes all the issues found in the
tests.