### PR TITLE
Add names to the travis jobs to better identify them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,19 @@ matrix:
   include:
     - python: "3.5"
       env: TOXENV=py35
+      name: "Python 3.5 Tests"
     - python: "3.6"
       env: TOXENV=py36
+      name: "Python 3.6 Tests"
     - os: linux
       dist: xenial
       python: "3.7"
       env: TOXENV=py37
       sudo: true
+      name: "Python 3.7 Tests"
     - python: "3.5"
       env: TOXENV=lint
+      name: "Linter Checks"
 
 language: python
 install: pip install -U tox


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now when checking the status of a travis run the jobs aren't
identified by a name. You can figure out what each job is based on the
python version and the environment variables set. But, to make it a bit
easier this commit adds a name so each job is uniquely labeled and more
easily identifiable.

### Details and comments