### PR TITLE
Add appveyor config to test on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,18 +6,21 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
-    - PYTHON: "C:\\Miniconda37-x64"
-      PYTHON_VERSION: "3.7.0"
-      PYTHON_ARCH: "64"
-      TOX_ENV: "py37"
-    - PYTHON: "C:\\Miniconda36-x64"
+# NOTE(mtreinish): Python 3.7 and Python 3.5 temporarily disabled because of
+# broken Aer wheels for windows:
+#    - PYTHON: "C:\\Miniconda37-x64"
+#      PYTHON_VERSION: "3.7.0"
+#      PYTHON_ARCH: "64"
+#      TOX_ENV: "py37"
+#    - PYTHON: "C:\\Miniconda35-x64"
+#      PYTHON_VERSION: "3.5.3"
+#      PYTHON_ARCH: "64"
+#      TOX_ENV: "py35"
+    - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
       TOX_ENV: "py36"
-    - PYTHON: "C:\\Miniconda35-x64"
-      PYTHON_VERSION: "3.5.3"
-      PYTHON_ARCH: "64"
-      TOX_ENV: "py35"
+
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.
@@ -44,13 +47,8 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  - "conda update -y pip conda"
-  - "conda install --update-deps -y mkl vs2015_runtime"
-  - "conda install -y -c conda-forge openblas"
-  - ps: |
-      if ($env:TOX_ENV -eq "py35") {
-        conda install -y python=3.5.0
-      }
+#  - "conda update -y pip conda"
+#  - "conda install --update-deps -y mkl vs2015_runtime"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --upgrade pip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ install:
   # about it being out of date.
   - "conda update -y pip"
   - "python -m pip install --disable-pip-version-check --upgrade pip"
-  - "python -m pip install tox"
+  - "pip install tox"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  - "conda install -y --all mkl"
+  - "conda install --update-all --update-deps -y mkl"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --user --upgrade pip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,15 +6,15 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
-    - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7.0"
       PYTHON_ARCH: "64"
       TOX_ENV: "py37"
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
       TOX_ENV: "py36"
-    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.3"
       PYTHON_ARCH: "64"
       TOX_ENV: "py35"
@@ -57,6 +57,7 @@ install:
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
   - "pip install -U tox"
+  - "conda install mkl"
 
 build_script:
   - "tox -e%TOX_ENV% --notest"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   - "conda update -y pip conda"
-  - "conda install --update-deps -y mkl numpy vs2015_runtime"
+  - "conda install --update-deps -y mkl vs2015_runtime"
   - "conda install -y -c conda-forge openblas"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
+  #- "python -m pip install --disable-pip-version-check --user --upgrade pip"
 
   # Install the build dependencies of the project. If some dependencies contain
   # compiled extensions and are not provided as pre-built wheel packages,

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,8 +52,8 @@ install:
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "conda update -y pip"
-  #  - "python -m pip install --disable-pip-version-check --upgrade pip"
-  - "python -m pip install --disable-pip-version-check tox"
+  - "python -m pip install --disable-pip-version-check --upgrade pip"
+  - "python -m pip install tox"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,7 +57,7 @@ install:
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
   - "pip install -U tox"
-  - "conda install mkl"
+  - "conda install -y mkl"
 
 build_script:
   - "tox -e%TOX_ENV% --notest"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,10 +35,6 @@ install:
   - ECHO "Installed SDKs:"
   - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
 
- # Install Python (from the official .msi of http://python.org) and pip when
-  # not already installed.
-  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
-
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).
@@ -51,6 +47,10 @@ install:
   - "conda update -y pip conda"
   - "conda install --update-deps -y mkl vs2015_runtime"
   - "conda install -y -c conda-forge openblas"
+  - ps: |
+      if ($env:TOX_ENV -eq "py35") {
+        conda install -y python=3.5.0
+      }
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --upgrade pip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,66 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.0"
+      PYTHON_ARCH: "64"
+      TOX_ENV: "py37"
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.1"
+      PYTHON_ARCH: "64"
+      TOX_ENV: "py36"
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.3"
+      PYTHON_ARCH: "64"
+      TOX_ENV: "py35"
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  - ECHO "Installed SDKs:"
+  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+
+ # Install Python (from the official .msi of http://python.org) and pip when
+  # not already installed.
+  - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
+
+  # Prepend newly installed Python to the PATH of this build (this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+  # Check that we have the expected version and architecture for Python
+  - "python --version"
+  - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
+
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
+
+  # Install the build dependencies of the project. If some dependencies contain
+  # compiled extensions and are not provided as pre-built wheel packages,
+  # pip will build them from source using the MSVC compiler matching the
+  # target Python version and architecture
+  - "pip install -U tox"
+
+build_script:
+  - "tox -e%TOX_ENV% --notest"
+
+test_script:
+  # Run the project tests
+  - "tox -e%TOX_ENV%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,8 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  - "conda install --update-all --update-deps -y mkl"
+  - "conda install --update-deps -y mkl"
+  - "conda update -y pip"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --user --upgrade pip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,11 +48,11 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
+  - "conda update -y pip conda"
   - "conda install --update-deps -y mkl numpy vs2015_runtime"
+  - "conda install -y -c conda-forge openblas"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "conda update -y pip"
-  - "conda install -c -y conda-forge openblas"
   - "python -m pip install --disable-pip-version-check --upgrade pip"
   - "pip install tox"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,11 +49,11 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   - "conda install --update-deps -y mkl"
-  - "conda update -y pip"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
-  - "python -m pip install --disable-pip-version-check --user tox"
+  - "conda update -y pip"
+  #  - "python -m pip install --disable-pip-version-check --upgrade pip"
+  - "python -m pip install --disable-pip-version-check tox"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
 #      PYTHON_VERSION: "3.5.3"
 #      PYTHON_ARCH: "64"
 #      TOX_ENV: "py35"
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"
       TOX_ENV: "py36"
@@ -47,8 +47,7 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-#  - "conda update -y pip conda"
-#  - "conda install --update-deps -y mkl vs2015_runtime"
+  - "conda install --update-deps -y mkl"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --upgrade pip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,10 +48,11 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  - "conda install --update-deps -y mkl"
+  - "conda install --update-deps -y mkl numpy vs2015_runtime"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "conda update -y pip"
+  - "conda install -c -y conda-forge openblas"
   - "python -m pip install --disable-pip-version-check --upgrade pip"
   - "pip install tox"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,19 +48,13 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
+  - "conda install -y --all mkl"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  #- "python -m pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --disable-pip-version-check --user tox"
 
-  # Install the build dependencies of the project. If some dependencies contain
-  # compiled extensions and are not provided as pre-built wheel packages,
-  # pip will build them from source using the MSVC compiler matching the
-  # target Python version and architecture
-  - "pip install -U tox"
-  - "conda install -y mkl"
-
-build_script:
-  - "tox -e%TOX_ENV% --notest"
+build: off
 
 test_script:
   # Run the project tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 cvxpy>=1.0.15
 cvxopt>=1.2.3
-#qiskit-aer>=0.1.1
+qiskit-aer>=0.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 cvxpy>=1.0.15
 cvxopt>=1.2.3
-qiskit-aer>=0.1.1
+#qiskit-aer>=0.1.1

--- a/test/rb/test_clifford.py
+++ b/test/rb/test_clifford.py
@@ -41,32 +41,27 @@ class TestClifford(unittest.TestCase):
         """
             test: generating the tables for 1 and 2 qubits
         """
-        test_tables_fd, test_tables_file_path = tempfile.mkstemp()
-        self.addCleanup(os.remove, test_tables_file_path)
-        with os.fdopen(test_tables_fd, mode='w') as test_tables_file:
-            test_tables_file.write(
-                "test: generating the clifford group table for 1 qubit:\n")
-            clifford1 = clutils.clifford1_gates_table()
-            test_tables_file.write(str(len(clifford1)))
-            test_tables_file.write("\n")
-            test_tables_file.write(str(sorted(clifford1.values())))
-            test_tables_file.write("\n")
-            test_tables_file.write(
-                "-------------------------------------------------------\n")
+        test_tables_content = []
+        test_tables_content.append(
+            "test: generating the clifford group table for 1 qubit:\n")
+        clifford1 = clutils.clifford1_gates_table()
+        test_tables_content.append(str(len(clifford1)) + '\n')
+        test_tables_content.append(str(sorted(clifford1.values())) + '\n')
+        test_tables_content.append(
+            "-------------------------------------------------------\n")
 
-            test_tables_file.write(
-                "test: generating the clifford group table for 2 qubits:\n")
-            clifford2 = clutils.clifford2_gates_table()
-            test_tables_file.write(str(len(clifford2)))
-            test_tables_file.write("\n")
-            test_tables_file.write(str(sorted(clifford2.values())))
-            test_tables_file.write("\n")
+        test_tables_content.append(
+            "test: generating the clifford group table for 2 qubits:\n")
+        clifford2 = clutils.clifford2_gates_table()
+        test_tables_content.append(str(len(clifford2)) + '\n')
+        test_tables_content.append(str(sorted(clifford2.values())) + '\n')
         expected_file_path = os.path.join(
             os.path.dirname(__file__),
             'test_tables_expected.txt')
-        self.assertTrue(
-            filecmp.cmp(test_tables_file_path, expected_file_path),
-            "Error: tables on 1 and 2 qubits are not the same")
+        with open(expected_file_path, 'r') as fd:
+            expected_file_content = fd.readlines()
+        self.assertEqual(expected_file_content, test_tables_content,
+                         "Error: tables on 1 and 2 qubits are not the same")
 
     def test_random_and_inverse(self):
         """
@@ -76,40 +71,37 @@ class TestClifford(unittest.TestCase):
         clifford_tables = [[]]*self.max_nq
         clifford_tables[0] = clutils.clifford1_gates_table()
         clifford_tables[1] = clutils.clifford2_gates_table()
-        test_random_fd, test_random_file_path = tempfile.mkstemp()
-        self.addCleanup(os.remove, test_random_file_path)
-        with os.fdopen(test_random_fd, mode='w') as test_random_file:
-
-            # test: generating a pseudo-random Clifford using tables -
-            # 1&2 qubits and computing its inverse
-            for nq in range(1, 1+self.max_nq):
-                for i in range(0, self.number_of_tests):
-                    my_seed = i
-                    np.random.seed(my_seed)
-                    random.seed(my_seed)
-                    test_random_file.write(
-                        "test: generating a pseudo-random clifford using the "
-                        "tables - %d qubit - seed=%d:\n" % (nq, my_seed))
-                    cliff_nq = clutils.random_clifford_gates(nq)
-                    test_random_file.write(str(cliff_nq))
-                    test_random_file.write("\n")
-                    test_random_file.write(
-                        "test: inverting a pseudo-random clifford using the "
-                        "tables - %d qubit - seed=%d:\n" % (nq, my_seed))
-                    inv_cliff_nq = clutils.find_inverse_clifford_gates(
-                        nq, cliff_nq)
-                    test_random_file.write(str(inv_cliff_nq))
-                    test_random_file.write("\n")
-                    test_random_file.write(
-                        "-----------------------------------------------------"
-                        "--\n")
+        test_random_file_content = []
+        # test: generating a pseudo-random Clifford using tables -
+        # 1&2 qubits and computing its inverse
+        for nq in range(1, 1+self.max_nq):
+            for i in range(0, self.number_of_tests):
+                my_seed = i
+                np.random.seed(my_seed)
+                random.seed(my_seed)
+                test_random_file_content.append(
+                    "test: generating a pseudo-random clifford using the "
+                    "tables - %d qubit - seed=%d:\n" % (nq, my_seed))
+                cliff_nq = clutils.random_clifford_gates(nq)
+                test_random_file_content.append(str(cliff_nq) + '\n')
+                test_random_file_content.append(
+                    "test: inverting a pseudo-random clifford using the "
+                    "tables - %d qubit - seed=%d:\n" % (nq, my_seed))
+                inv_cliff_nq = clutils.find_inverse_clifford_gates(
+                    nq, cliff_nq)
+                test_random_file_content.append(str(inv_cliff_nq) + '\n')
+                test_random_file_content.append(
+                    "-----------------------------------------------------"
+                    "--\n")
 
         expected_file_path = os.path.join(
             os.path.dirname(__file__),
             'test_random_expected.txt')
-        self.assertTrue(
-            filecmp.cmp(test_random_file_path, expected_file_path),
-            "Error: random and/or inverse cliffords are not the same")
+        with open(expected_file_path, 'r') as fd:
+            expected_file_content = fd.readlines()
+        self.assertEqual(expected_file_content, test_random_file_content,
+                         "Error: random and/or inverse cliffords are not "
+                         "the same")
 
 
 if __name__ == '__main__':

--- a/test/rb/test_clifford.py
+++ b/test/rb/test_clifford.py
@@ -15,10 +15,8 @@ Test Clifford functions:
 """
 
 import unittest
-import filecmp
 import random
 import os
-import tempfile
 import numpy as np
 
 # Import the clifford_utils functions


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We support running ignis on windows, osx, and linux but we only
currently test running things on linux. This commit adds the initial
config for running tests under windows too so we can verify that it
works as expected.

### Details and comments

This does not add jobs for python 3.7 and 3.5 because the qiskit-aer
wheels published on pypi are broken and unusable. There is also no
sdist published to automate a build via pip. Cloning and building qiskit-aer
from source isn't worth it just for unit testing python 3.7 and 3.5 on
windows. So until there are working Aer builds published on pypi this
commit just leaves those jobs commented out. We can add them when/if
there are working windows wheels for python 3.7 and 3.5.