### PR TITLE
Removed usage of depracated compile

### DIFF
--- a/test/measurement_calibration/test_meas.py
+++ b/test/measurement_calibration/test_meas.py
@@ -120,9 +120,8 @@ class TestMeasCal(unittest.TestCase):
 
                 # Perform an ideal execution on the generated circuits
                 backend = Aer.get_backend('qasm_simulator')
-                qobj = qiskit.compile(meas_calibs, backend=backend,
-                                      shots=self.shots)
-                job = backend.run(qobj)
+                job = qiskit.execute(meas_calibs, backend=backend,
+                                     shots=self.shots)
                 cal_results = job.result()
 
                 # Make a calibration matrix
@@ -188,9 +187,8 @@ class TestMeasCal(unittest.TestCase):
 
                     # Run the calibration circuits
                     backend = Aer.get_backend('qasm_simulator')
-                    qobj = qiskit.compile(meas_calibs, backend=backend,
-                                          shots=self.shots)
-                    job = backend.run(qobj)
+                    job = qiskit.execute(meas_calibs, backend=backend,
+                                         shots=self.shots)
                     cal_results = job.result()
 
                     # Make a calibration matrix
@@ -208,9 +206,8 @@ class TestMeasCal(unittest.TestCase):
                     ghz.measure(qr[q2], cr[1])
                     ghz.measure(qr[q3], cr[2])
 
-                    qobj = qiskit.compile([ghz], backend=backend,
-                                          shots=self.shots)
-                    job = backend.run(qobj)
+                    job = qiskit.execute([ghz], backend=backend,
+                                         shots=self.shots)
                     results = job.result()
 
                     # Predicted equally distributed results


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The `compile` function is deprecated. This PR cleans Ignis from usage of this function.

### Details and comments

Related to #154
