### PR TITLE
Stop building aer from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ addons:
     packages:
       - gcc-4.8
       - g++-4.8
-      - libopenblas-dev
-      - g++-7
-      - cmake
-      - cython3
 
 install_osx: &stage_osx
   os: osx
@@ -89,9 +85,9 @@ matrix:
         - TOXENV=py37
 
 language: python
-install: pip install -U tox pip tox-pip-version
+install: pip install -U tox pip
 script:
-  - travis_wait tox
+  - tox
 
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,13 +45,11 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  - "conda install --update-deps -y mkl vs2017_win-64 vs2017_win-32 msvc_runtime"
-  # Aer build requirements
-  - "conda install --update-deps -c conda-forge -y openblas cmake"
-  - "conda install -y pip=18.1 virtualenv"
+  - "conda install --update-deps -y mkl"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install tox tox-virtualenv-no-download"
+  - "python -m pip install --disable-pip-version-check --upgrade pip"
+  - "pip install tox"
 
 build: off
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,18 +6,13 @@ skipsdist = True
 [testenv]
 usedevelop = true
 install_command = pip install -U {opts} {packages}
-pip_version = 18.1
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
-  CMAKE_CXX_COMPILER=g++-7
 deps = numpy>=1.13
-       Cython>=0.27.1
 commands =
     pip install -U git+https://github.com/Qiskit/qiskit-terra.git
-    pip install -U scikit-build
-    python tools/build_aer.py
     pip install -U -r{toxinidir}/requirements-dev.txt
     python -m unittest -v
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ setenv =
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
 deps = numpy>=1.13
+       Cython>=0.27.1
 commands =
     pip install -U git+https://github.com/Qiskit/qiskit-terra.git
     pip install -U -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Building aer from source is very slow, unreliable, and doesn't work on
windows at all. It also requires a lot of hacks to even work in the CI
system. This was only needed because terra master (soon to be 0.8)
didn't work with the latest release of aer (0.1.1). However, now that
Qiskit/qiskit-terra#2154 has merged we should be able to use master
terra with the released version of Aer. So we can stop building it from
source and speed up and improve our jobs.

### Details and comments

This is effectively a revert of #162 
Fixes #160 
