### PR TITLE
Re-enable python 3.5 windows test job on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ install:
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --upgrade pip"
-  - "pip install tox"
+  - "pip install --ignore-installed tox"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,10 @@ environment:
   matrix:
 # NOTE(mtreinish): Python 3.7 and Python 3.5 temporarily disabled because of
 # broken Aer wheels for windows:
-    - PYTHON: "C:\\Miniconda37-x64"
-      PYTHON_VERSION: "3.7.0"
-      PYTHON_ARCH: "64"
-      TOX_ENV: "py37"
+#    - PYTHON: "C:\\Miniconda37-x64"
+#      PYTHON_VERSION: "3.7.0"
+#      PYTHON_ARCH: "64"
+#      TOX_ENV: "py37"
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5.3"
       PYTHON_ARCH: "64"
@@ -46,7 +46,6 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   - "conda install --update-deps -y mkl"
-  - "conda install -c conda-forge --update-deps -y cvxopt"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --upgrade pip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   - "conda install --update-deps -y mkl"
+  - "conda install -c conda-forge --update-deps -y cvxopt"
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   - "python -m pip install --disable-pip-version-check --upgrade pip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,14 +9,14 @@ environment:
   matrix:
 # NOTE(mtreinish): Python 3.7 and Python 3.5 temporarily disabled because of
 # broken Aer wheels for windows:
-#    - PYTHON: "C:\\Miniconda37-x64"
-#      PYTHON_VERSION: "3.7.0"
-#      PYTHON_ARCH: "64"
-#      TOX_ENV: "py37"
-#    - PYTHON: "C:\\Miniconda35-x64"
-#      PYTHON_VERSION: "3.5.3"
-#      PYTHON_ARCH: "64"
-#      TOX_ENV: "py35"
+    - PYTHON: "C:\\Miniconda37-x64"
+      PYTHON_VERSION: "3.7.0"
+      PYTHON_ARCH: "64"
+      TOX_ENV: "py37"
+    - PYTHON: "C:\\Miniconda35-x64"
+      PYTHON_VERSION: "3.5.3"
+      PYTHON_ARCH: "64"
+      TOX_ENV: "py35"
     - PYTHON: "C:\\Miniconda36-x64"
       PYTHON_VERSION: "3.6.1"
       PYTHON_ARCH: "64"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Now that we have a new aer release with new prebuilt binaries hosted on
pypi the new binaries work in the windows CI environment on appveyor now.
Previously we disabled the windows testing on python 3.5 and 3.7 because the
binaries published for aer 0.1.1 did not work, but since the new version works it'll
be good to verify that ignis and all proposed patches run on all 3 supported
version of python on windows. However, there is still an issue running with the
cvxopt solver used in the tomography tests on windows and python 3.7. So this
PR only re-enables windows testing for Python 3.5 and leaves Python 3.7 disabled
still for now.

### Details and comments