### PR TITLE
Don't install terra from master in tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ setenv =
 deps = numpy>=1.13
        Cython>=0.27.1
 commands =
-    pip install -U git+https://github.com/Qiskit/qiskit-terra.git
     pip install -U -r{toxinidir}/requirements-dev.txt
     python -m unittest -v
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Now that terra 0.8.x is out ignis doesn't have any requirements on
terra >0.8.x now. However it's not keeping up with the breaking changes being
made in terra's master branch. For the time being remove the step
install terra from master to avoid breakages by terra development.
When/if we need to ensure compatibility with a newer version of terra we
can bump the minimum version and add terra from master back to the
test environments.

### Details and comments