### PR TITLE
Add pypi automation for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,14 @@ matrix:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.7.2
         - TOXENV=py37
+    - if: tag IS present
+      python: "3.6"
+      env:
+        - TWINE_USERNAME=qiskit
+      install: pip install -U twine
+      script:
+        - python3 setup.py sdist bdist_wheel
+        - twine upload dist/qiskit*
 
 language: python
 install: pip install -U tox pip


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of streamlining the release process, this commit adds automation
for publishing to pypi. For the metapackage this is straightforward
since we only publish an sdist right now and there is no code we just
need to build an sdist and a python3 wheel and then upload both to pypi.
This takes another manual step out of the release process and all that
is necessary is to push a tag (or use github's ui for creating a tag
and/or release).

### Details and comments
