### PR TITLE
Replaced deprecated qubit[0] with qubit.register

### DIFF
--- a/qiskit/ignis/verification/tomography/basis/sicbasis.py
+++ b/qiskit/ignis/verification/tomography/basis/sicbasis.py
@@ -41,7 +41,7 @@ def sicpovm_preparation_circuit(op, qubit):
     Returns:
         A QuantumCircuit object.
     """
-    circ = QuantumCircuit(qubit[0])
+    circ = QuantumCircuit(qubit.register)
     theta = -2 * np.arctan(np.sqrt(2))
     if op == 'S1':
         circ.u3(theta, np.pi, 0.0, qubit)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The deprecation warning is displayed when the process tomography notebook is executed.

### Details and comments


