### PR TITLE
Small changes in the guess values of RBFitter.fit_data and fit bounds

### DIFF
--- a/qiskit/ignis/verification/randomized_benchmarking/fitters.py
+++ b/qiskit/ignis/verification/randomized_benchmarking/fitters.py
@@ -418,7 +418,7 @@ class RBFitter(RBFitterBase):
             if y0 > fit_guess[2]:
                 fit_guess[0] = ((y0 - fit_guess[2]) /
                                 fit_guess[1]**self._cliff_lengths[patt_ind][0])
-                
+
             self.fit_data_pattern(patt_ind, tuple(fit_guess))
 
     def plot_rb_data(self, pattern_index=0, ax=None,

--- a/qiskit/ignis/verification/randomized_benchmarking/fitters.py
+++ b/qiskit/ignis/verification/randomized_benchmarking/fitters.py
@@ -370,7 +370,7 @@ class RBFitter(RBFitterBase):
                                  self._ydata[patt_ind]['mean'],
                                  sigma=sigma,
                                  p0=fit_guess,
-                                 bounds=([-2, 0, -2], [2, 1, 2]))
+                                 bounds=([0, 0, 0], [1, 1, 1]))
         alpha = params[1]  # exponent
         params_err = np.sqrt(np.diag(pcov))
         alpha_err = params_err[1]

--- a/qiskit/ignis/verification/randomized_benchmarking/fitters.py
+++ b/qiskit/ignis/verification/randomized_benchmarking/fitters.py
@@ -400,10 +400,9 @@ class RBFitter(RBFitterBase):
         for patt_ind, _ in enumerate(self._rb_pattern):
 
             qubits = self._rb_pattern[patt_ind]
-            fit_guess = [0.95, 0.99, 0.0]
-            fit_guess[0] = self._ydata[patt_ind]['mean'][0]
+
             # Should decay to 1/2^n
-            fit_guess[2] = 1/2**len(qubits)
+            fit_guess = [0.95, 0.99, 1/2**len(qubits)]
 
             # Use the first two points to guess the decay param
             y0 = self._ydata[patt_ind]['mean'][0]
@@ -416,8 +415,10 @@ class RBFitter(RBFitterBase):
             if alpha_guess < 1.0:
                 fit_guess[1] = alpha_guess
 
-            fit_guess[0] = ((y0 - fit_guess[2]) /
-                            fit_guess[1]**self._cliff_lengths[patt_ind][0])
+            if y0 > fit_guess[2]:
+                fit_guess[0] = ((y0 - fit_guess[2]) /
+                                fit_guess[1]**self._cliff_lengths[patt_ind][0])
+                
             self.fit_data_pattern(patt_ind, tuple(fit_guess))
 
     def plot_rb_data(self, pattern_index=0, ax=None,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

a\alpha^x+b expresses a probability, therefore must be in the range [0, 1].

### Details and comments

1. Fixed the bounds such that a and b are in the range [0, 1].
2. Removed the line that sets a to y0, because I don't see the rationale behind it.
3. Conditioned the line that sets a to (y0-b)/(alpha^x0) with the constraint (y0>b).
