### PR TITLE
Make azure pipeline steps fail on intermediate commands

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,11 +28,13 @@ steps:
     displayName: Create Anaconda environment
   - bash: |
       set -e
+      set -x
       activate qiskit-ignis
       conda install --yes --quiet --name qiskit-ignis python=$PYTHON_VERSION mkl
     displayName: Install Anaconda packages
   - bash: |
       set -e
+      set -x
       activate qiskit-ignis
       python -m pip install --upgrade pip
       pip install tox

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,12 +29,12 @@ steps:
   - bash: |
       set -e
       activate qiskit-ignis
-      conda install --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION% mkl
+      conda install --yes --quiet --name qiskit-ignis python=$PYTHON_VERSION mkl
     displayName: Install Anaconda packages
   - bash: |
       set -e
       activate qiskit-ignis
       python -m pip install --upgrade pip
       pip install tox
-      tox -e%TOXENV%
+      tox -e$TOXENV
     displayName: 'Install dependencies and run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,12 +26,14 @@ steps:
     displayName: Add conda to PATH
   - script: conda create --yes --quiet --name qiskit-ignis
     displayName: Create Anaconda environment
-  - script: |
-      call activate qiskit-ignis
+  - bash: |
+      set -e
+      activate qiskit-ignis
       conda install --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION% mkl
     displayName: Install Anaconda packages
-  - script: |
-      call activate qiskit-ignis
+  - bash: |
+      set -e
+      activate qiskit-ignis
       python -m pip install --upgrade pip
       pip install tox
       tox -e%TOXENV%


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The azure pipelines commands were previously using the script directive
which on windows uses cmd.exe to run commands. The return code for the
step process only returns non-zero and exits if the last command in the
script returns non-zero, it will continue running if an intermediate
command fails. This can lead to hard to parse errors because something
failed earlier in the pipeline and we don't catch it until later. For
example pip install tox failing because of a network issue and then we
get a command not found error for tox later when it goes to run tests.
This commit fixes this potential issue by switching all the script to
use base and then using 'set -e' to set errexit to make sure any failing
command causes the job to fail there.

### Details and comments


