### PR TITLE
Revert "Make azure pipeline steps fail on intermediate commands (#248)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,17 +26,13 @@ steps:
     displayName: Add conda to PATH
   - script: conda create --yes --quiet --name qiskit-ignis
     displayName: Create Anaconda environment
-  - bash: |
-      set -e
-      set -x
-      activate qiskit-ignis
-      conda install --yes --quiet --name qiskit-ignis python=$PYTHON_VERSION mkl
+  - script: |
+      call activate qiskit-ignis
+      conda install --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION% mkl
     displayName: Install Anaconda packages
-  - bash: |
-      set -e
-      set -x
-      activate qiskit-ignis
+  - script: |
+      call activate qiskit-ignis
       python -m pip install --upgrade pip
       pip install tox
-      tox -e$TOXENV
+      tox -e%TOXENV%
     displayName: 'Install dependencies and run tests'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR was merged by mistake before it was ready. The switch to bash
scripts breaks the anaconda commands. It still needs to be debugged.
Eventually we'll want this change because it'll make our jobs more
reliable in the long run. But the last details still need to be worked
out. This commit reverts the change to unblock the windows CI until it
is ready.

### Details and comments

This reverts commit e3420a6f88bc1e345cf4ba349545d290785d549e.