### PR TITLE
Split up test_rb using ddt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ cvxpy>=1.0.15
 cvxopt>=1.2.3
 qiskit-aer>=0.1.1
 stestr>=2.5.0
+ddt>=1.2.0

--- a/test/rb/test_rb.py
+++ b/test/rb/test_rb.py
@@ -19,13 +19,18 @@ Run through RB for different qubit numbers to check that it's working
 and that it returns the identity
 """
 
-import unittest
+import itertools
 import random
+import unittest
+
 import numpy as np
+from ddt import ddt, data, unpack
+
 import qiskit
 import qiskit.ignis.verification.randomized_benchmarking as rb
 
 
+@ddt
 class TestRB(unittest.TestCase):
     """ The test class """
 
@@ -388,177 +393,167 @@ class TestRB(unittest.TestCase):
                          "Error: The last purity gates in the \
                          %d qubit purity RB are wrong" % nq)
 
-    def test_rb(self):
+    @data(*itertools.product([1, 2, 3, 4], range(3), range(2)))
+    @unpack
+    def test_rb(self, nq, pattern_type, multiplier_type):
         """ Main function of the test """
 
         # Load simulator
         backend = qiskit.Aer.get_backend('qasm_simulator')
 
-        # Test up to 4 qubits (only 1-qubit and 2-qubit RB)
-        nq_list = [1, 2, 3, 4]
+        # See documentation of choose_pattern for the meaning of
+        # the different pattern types
+        # Choose options for standard (simultaneous) RB:
+        rb_opts = {}
+        rb_opts['nseeds'] = 3
+        rb_opts['length_vector'] = [1, 3, 4, 7]
+        rb_opts['rb_pattern'], is_purity = \
+            self.choose_pattern(pattern_type, nq)
+        # if the pattern type is not relevant for nq
+        if rb_opts['rb_pattern'] is None:
+            raise unittest.SkipTest('pattern type is not relevant for nq')
+        rb_opts_purity = rb_opts.copy()
+        rb_opts['length_multiplier'] = self.choose_multiplier(
+            multiplier_type, len(rb_opts['rb_pattern']))
+        # Choose options for interleaved RB:
+        rb_opts_interleaved = rb_opts.copy()
+        rb_opts_interleaved['interleaved_gates'] = \
+            self.choose_interleaved_gates(rb_opts['rb_pattern'])
+        # Choose options for purity rb
+        # no length_multiplier
+        rb_opts_purity['length_multiplier'] = 1
+        rb_opts_purity['is_purity'] = is_purity
+        if multiplier_type > 0:
+            is_purity = False
+        # Adding seed_offset and align_cliffs
+        rb_opts['seed_offset'] = 10
+        rb_opts['align_cliffs'] = True
 
-        for nq in nq_list:
+        # Generate the sequences
+        try:
+            # Standard (simultaneous) RB sequences:
+            rb_circs, _ = rb.randomized_benchmarking_seq(**rb_opts)
+            # Interleaved RB sequences:
+            rb_original_circs, _, rb_interleaved_circs = \
+                rb.randomized_benchmarking_seq(
+                    **rb_opts_interleaved)
+            # Purity RB sequences:
+            if is_purity:
+                rb_purity_circs, _, npurity = \
+                    rb.randomized_benchmarking_seq(
+                        **rb_opts_purity)
+                # verify: npurity = 3^n
+                self.assertEqual(
+                    npurity, 3 ** len(rb_opts['rb_pattern'][0]),
+                    'Error: npurity does not equal to 3^n')
 
-            print("Testing %d qubit RB" % nq)
+        except OSError:
+            skip_msg = ('Skipping tests for %s qubits because '
+                        'tables are missing' % str(nq))
+            raise unittest.SkipTest(skip_msg)
 
-            for pattern_type in range(3):
-                for multiplier_type in range(2):
-                    # See documentation of choose_pattern for the meaning of
-                    # the different pattern types
-                    # Choose options for standard (simultaneous) RB:
-                    rb_opts = {}
-                    rb_opts['nseeds'] = 3
-                    rb_opts['length_vector'] = [1, 3, 4, 7]
-                    rb_opts['rb_pattern'], is_purity = \
-                        self.choose_pattern(pattern_type, nq)
-                    # if the pattern type is not relevant for nq
-                    if rb_opts['rb_pattern'] is None:
-                        continue
-                    rb_opts_purity = rb_opts.copy()
-                    rb_opts['length_multiplier'] = self.choose_multiplier(
-                        multiplier_type, len(rb_opts['rb_pattern']))
-                    # Choose options for interleaved RB:
-                    rb_opts_interleaved = rb_opts.copy()
-                    rb_opts_interleaved['interleaved_gates'] = \
-                        self.choose_interleaved_gates(rb_opts['rb_pattern'])
-                    print('rb_opts:', rb_opts_interleaved)
-                    # Choose options for purity rb
-                    # no length_multiplier
-                    rb_opts_purity['length_multiplier'] = 1
-                    rb_opts_purity['is_purity'] = is_purity
-                    if multiplier_type > 0:
-                        is_purity = False
-                    if is_purity:
-                        print('Testing purity RB')
-                    # Adding seed_offset and align_cliffs
-                    rb_opts['seed_offset'] = 10
-                    rb_opts['align_cliffs'] = True
+        # Perform an ideal execution on the generated sequences
+        basis_gates = ['u1', 'u2', 'u3', 'cx']
+        shots = 100
+        result = []
+        result_original = []
+        result_interleaved = []
+        if is_purity:
+            result_purity = [[] for d in range(npurity)]
+        for seed in range(rb_opts['nseeds']):
+            result.append(
+                qiskit.execute(rb_circs[seed], backend=backend,
+                               basis_gates=basis_gates,
+                               shots=shots).result())
+            result_original.append(
+                qiskit.execute(rb_original_circs[seed],
+                               backend=backend,
+                               basis_gates=basis_gates,
+                               shots=shots).result())
+            result_interleaved.append(
+                qiskit.execute(rb_interleaved_circs[seed],
+                               backend=backend,
+                               basis_gates=basis_gates,
+                               shots=shots).result())
+            if is_purity:
+                for d in range(npurity):
+                    result_purity[d].append(qiskit.execute(
+                        rb_purity_circs[seed][d],
+                        backend=backend,
+                        basis_gates=basis_gates,
+                        shots=shots).result())
 
-                    # Generate the sequences
-                    try:
-                        # Standard (simultaneous) RB sequences:
-                        rb_circs, _ = rb.randomized_benchmarking_seq(**rb_opts)
-                        # Interleaved RB sequences:
-                        rb_original_circs, _, rb_interleaved_circs = \
-                            rb.randomized_benchmarking_seq(
-                                **rb_opts_interleaved)
-                        # Purity RB sequences:
-                        if is_purity:
-                            rb_purity_circs, _, npurity = \
-                                rb.randomized_benchmarking_seq(
-                                    **rb_opts_purity)
-                            # verify: npurity = 3^n
-                            self.assertEqual(
-                                npurity, 3 ** len(rb_opts['rb_pattern'][0]),
-                                'Error: npurity does not equal to 3^n')
+        # Verify the generated sequences
+        for seed in range(rb_opts['nseeds']):
+            length_vec = rb_opts['length_vector']
+            for circ_index, vec_len in enumerate(length_vec):
+                # Verify circuits names
+                self.assertEqual(
+                    rb_circs[seed][circ_index].name,
+                    'rb_length_%d_seed_%d' % (
+                        circ_index, seed +
+                        rb_opts['seed_offset']),
+                    'Error: incorrect circuit name')
+                self.assertEqual(
+                    rb_original_circs[seed][circ_index].name,
+                    'rb_length_%d_seed_%d' % (
+                        circ_index, seed),
+                    'Error: incorrect circuit name')
+                self.assertEqual(
+                    rb_interleaved_circs[seed][circ_index].name,
+                    'rb_interleaved_length_%d_seed_%d' % (
+                        circ_index, seed),
+                    'Error: incorrect interleaved circuit name')
+                if is_purity:
+                    for d in range(npurity):
+                        name_type, _ = self.update_purity_gates(
+                            npurity, d, rb_opts_purity
+                            ['rb_pattern'])
+                        self.assertEqual(
+                            rb_purity_circs[seed][d]
+                            [circ_index].name,
+                            'rb_purity_%s_length_%d_seed_%d' % (
+                                name_type, circ_index, seed),
+                            'Error: incorrect purity circuit name')
 
-                    except OSError:
-                        skip_msg = ('Skipping tests for %s qubits because '
-                                    'tables are missing' % str(nq))
-                        print(skip_msg)
-                        continue
+                self.verify_circuit(rb_circs[seed][circ_index],
+                                    nq, rb_opts,
+                                    vec_len, result[seed], shots)
+                self.verify_circuit(rb_original_circs[seed]
+                                    [circ_index],
+                                    nq, rb_opts,
+                                    vec_len,
+                                    result_original[seed], shots)
+                self.verify_circuit(rb_interleaved_circs[seed]
+                                    [circ_index],
+                                    nq, rb_opts_interleaved,
+                                    vec_len,
+                                    result_interleaved[seed],
+                                    shots,
+                                    is_interleaved=True)
+                if is_purity:
+                    self.verify_circuit(rb_purity_circs[seed][0]
+                                        [circ_index],
+                                        nq, rb_opts_purity,
+                                        vec_len, result_purity
+                                        [0][seed], shots)
+                    # compare the purity RB circuits
+                    # with the original circuit
+                    for d in range(1, npurity):
+                        self.compare_purity_circuits(
+                            rb_purity_circs[seed][0][circ_index],
+                            rb_purity_circs[seed][d][circ_index],
+                            nq, d, npurity, rb_opts_purity,
+                            vec_len)
+                # compare the interleaved RB circuits with
+                # the original RB circuits
+                self.compare_interleaved_circuit(
+                    rb_original_circs[seed][circ_index],
+                    rb_interleaved_circs[seed][circ_index],
+                    nq, rb_opts_interleaved, vec_len)
 
-                    # Perform an ideal execution on the generated sequences
-                    basis_gates = ['u1', 'u2', 'u3', 'cx']
-                    shots = 100
-                    result = []
-                    result_original = []
-                    result_interleaved = []
-                    result_purity = [[] for d in range(npurity)]
-                    for seed in range(rb_opts['nseeds']):
-                        result.append(
-                            qiskit.execute(rb_circs[seed], backend=backend,
-                                           basis_gates=basis_gates,
-                                           shots=shots).result())
-                        result_original.append(
-                            qiskit.execute(rb_original_circs[seed],
-                                           backend=backend,
-                                           basis_gates=basis_gates,
-                                           shots=shots).result())
-                        result_interleaved.append(
-                            qiskit.execute(rb_interleaved_circs[seed],
-                                           backend=backend,
-                                           basis_gates=basis_gates,
-                                           shots=shots).result())
-                        if is_purity:
-                            for d in range(npurity):
-                                result_purity[d].append(qiskit.execute(
-                                    rb_purity_circs[seed][d],
-                                    backend=backend,
-                                    basis_gates=basis_gates,
-                                    shots=shots).result())
-
-                    # Verify the generated sequences
-                    for seed in range(rb_opts['nseeds']):
-                        length_vec = rb_opts['length_vector']
-                        for circ_index, vec_len in enumerate(length_vec):
-                            # Verify circuits names
-                            self.assertEqual(
-                                rb_circs[seed][circ_index].name,
-                                'rb_length_%d_seed_%d' % (
-                                    circ_index, seed +
-                                    rb_opts['seed_offset']),
-                                'Error: incorrect circuit name')
-                            self.assertEqual(
-                                rb_original_circs[seed][circ_index].name,
-                                'rb_length_%d_seed_%d' % (
-                                    circ_index, seed),
-                                'Error: incorrect circuit name')
-                            self.assertEqual(
-                                rb_interleaved_circs[seed][circ_index].name,
-                                'rb_interleaved_length_%d_seed_%d' % (
-                                    circ_index, seed),
-                                'Error: incorrect interleaved circuit name')
-                            if is_purity:
-                                for d in range(npurity):
-                                    name_type, _ = self.update_purity_gates(
-                                        npurity, d, rb_opts_purity
-                                        ['rb_pattern'])
-                                    self.assertEqual(
-                                        rb_purity_circs[seed][d]
-                                        [circ_index].name,
-                                        'rb_purity_%s_length_%d_seed_%d' % (
-                                            name_type, circ_index, seed),
-                                        'Error: incorrect purity circuit name')
-
-                            self.verify_circuit(rb_circs[seed][circ_index],
-                                                nq, rb_opts,
-                                                vec_len, result[seed], shots)
-                            self.verify_circuit(rb_original_circs[seed]
-                                                [circ_index],
-                                                nq, rb_opts,
-                                                vec_len,
-                                                result_original[seed], shots)
-                            self.verify_circuit(rb_interleaved_circs[seed]
-                                                [circ_index],
-                                                nq, rb_opts_interleaved,
-                                                vec_len,
-                                                result_interleaved[seed],
-                                                shots,
-                                                is_interleaved=True)
-                            if is_purity:
-                                self.verify_circuit(rb_purity_circs[seed][0]
-                                                    [circ_index],
-                                                    nq, rb_opts_purity,
-                                                    vec_len, result_purity
-                                                    [0][seed], shots)
-                                # compare the purity RB circuits
-                                # with the original circuit
-                                for d in range(1, npurity):
-                                    self.compare_purity_circuits(
-                                        rb_purity_circs[seed][0][circ_index],
-                                        rb_purity_circs[seed][d][circ_index],
-                                        nq, d, npurity, rb_opts_purity,
-                                        vec_len)
-                            # compare the interleaved RB circuits with
-                            # the original RB circuits
-                            self.compare_interleaved_circuit(
-                                rb_original_circs[seed][circ_index],
-                                rb_interleaved_circs[seed][circ_index],
-                                nq, rb_opts_interleaved, vec_len)
-
-                    self.assertEqual(circ_index, len(rb_circs),
-                                     "Error: additional circuits exist")
+        self.assertEqual(circ_index, len(rb_circs),
+                         "Error: additional circuits exist")
 
     def test_rb_utils(self):
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The test_rb test case is the slowest test and is built by having
nested loops to go over all the combinations of the number of qubits,
rb pattern, and multiplier type. This results in 2 issues, first the
test case is quite slow, but more importantly it's very difficult to
debug. By running the same test code over and over again with different
parameters it makes detecting a problem harder (especially when tests
run in parallel) but also it makes reproducing a failure much more
difficult because there is no way to run the test with just one set of
input parameters.

This commit addresses this by switching the test to use ddt instead. ddt
will let us reuse the same test code from inside the loops but instead
of doing it one giant test case it will construct separate smaller test
cases for each input parameter combination. This leads to faster
execution when running in parallel because the scheduler can split the
test up over multiple workers. But also gives us a separate test case
that can be rerun by itself when an error is encountered.

### Details and comments


