### PR TITLE
Fix lint failures caused by new pylint and pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,14 +62,14 @@ matrix:
       dist: xenial
       python: "3.7"
       env: TOXENV=py37
-      sudo: true
       name: "Python 3.7 Tests"
       stage: all_python
-    - python: "3.5"
+    - python: "3.7"
+      dist: xenial
       env: TOXENV=lint
       name: "Linter Checks"
       stage: lint_and_python
-        # OSX, Python 3.5.6 (via pyenv)
+    # OSX, Python 3.5.6 (via pyenv)
     - stage: all_python
       name: "Python 3.5 Tests on OSX"
       <<: *stage_osx

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+pylint==2.4.2
+astroid==2.3.1

--- a/qiskit/ignis/mitigation/measurement/circuits.py
+++ b/qiskit/ignis/mitigation/measurement/circuits.py
@@ -134,7 +134,7 @@ def tensored_meas_cal(mit_pattern=None, qr=None, cr=None, circlabel=''):
 
     qubits_list_sizes = [len(qubit_list) for qubit_list in mit_pattern]
     nqubits = sum(qubits_list_sizes)
-    size_of_largest_group = max([list_size for list_size in qubits_list_sizes])
+    size_of_largest_group = max(qubits_list_sizes)
     largest_labels = count_keys(size_of_largest_group)
 
     state_labels = []

--- a/qiskit/ignis/verification/randomized_benchmarking/fitters.py
+++ b/qiskit/ignis/verification/randomized_benchmarking/fitters.py
@@ -36,36 +36,43 @@ class RBFitterBase(ABC):
         Abstract base class (ABS) for fitters for randomized benchmarking
     """
 
+    @property
     @abstractmethod
     def raw_data(self):
         """Return raw data."""
         return
 
+    @property
     @abstractmethod
     def cliff_lengths(self):
         """Return clifford lengths."""
         return
 
+    @property
     @abstractmethod
     def ydata(self):
         """Return ydata (means and std devs)."""
         return
 
+    @property
     @abstractmethod
     def fit(self):
         """Return fit."""
         return
 
+    @property
     @abstractmethod
     def rb_fit_fun(self):
         """Return the function rb_fit_fun."""
         return
 
+    @property
     @abstractmethod
     def seeds(self):
         """Return the number of loaded seeds."""
         return
 
+    @property
     @abstractmethod
     def results(self):
         """Return all the results."""
@@ -730,17 +737,15 @@ class InterleavedRBFitter(RBFitterBase):
                     marker='+')
 
         # Plot the fit
-        ax.plot(xdata,
-                self.rbfit_std.rb_fit_fun(xdata,
-                                          *self.fit[0]
-                                          [pattern_index]['params']),
+        std_fit_function = self.rbfit_std.rb_fit_fun
+        int_fit_function = self.rbfit_int.rb_fit_fun
+        ax.plot(xdata, std_fit_function(xdata,
+                                        *self.fit[0][pattern_index]['params']),
                 color='blue', linestyle='-', linewidth=2,
                 label='Standard RB')
         ax.tick_params(labelsize=14)
-        ax.plot(xdata,
-                self.rbfit_int.rb_fit_fun(xdata,
-                                          *self.fit[1]
-                                          [pattern_index]['params']),
+        ax.plot(xdata, int_fit_function(xdata,
+                                        *self.fit[1][pattern_index]['params']),
                 color='red', linestyle='-', linewidth=2,
                 label='Interleaved RB')
         ax.tick_params(labelsize=14)

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 
 [testenv]
 usedevelop = true
-install_command = pip install -U {opts} {packages}
+install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes all the issues reported via the newest pylint release.
After fixing all the reported errors this also adds a version pin using
a constraints file to ensure that we have a stable base for lint
checking. We can investigate bumping that pin at the future on our
terms instead of new pylint (or pylint's dependencies) releases breaking
CI periodically.

At the same time the python version used for the lint check is bumped to
3.7. The python version used for pylint can effect results returned,
pylint is very sensitive to the environment it's run in. Running on
python 3.5 which is the oldest supported python version masks issues on
newer python versions. For example, if you have python 3.7 installed
locally lint will always fail becaues of changes to the stdlib. This
starts to become more of an issue as a particular python version ages,
since the user and contributor base moves to newer versions of python.
This commit changes the version of pylint we run in CI to 3.7 to tests
the leading edge instead of the trailing so we keep our pylint testing
up to date with the python versions we support.

### Details and comments