### PR TITLE
Upgrade virtualenv to pull in latest pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ matrix:
         - twine upload dist/qiskit*
 
 language: python
-install: pip install -U tox pip
+install: pip install -U tox pip virtualenv
 script:
   - tox
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ steps:
     displayName: Install Anaconda packages
   - script: |
       call activate qiskit-ignis
-      python -m pip install --upgrade pip
+      python -m pip install --upgrade pip virtualenv
       pip install tox
       tox -e%TOXENV%
     displayName: 'Install dependencies and run tests'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Virtualenv bundles a pip version and if it's not updated with pip we can
end up with venvs that do not have the same version as installed in CI.
Since installing aer from wheel requires pip>=19 we need to ensure we
upgrade both pip and virtualenv at the same time to install new enough
pip for tox's venvs.

### Details and comments