### PR TITLE
Add docs job to run docs build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,32 +7,60 @@ trigger:
 - master
 - stable
 
-pool:
-  vmImage: 'vs2017-win2016'
-strategy:
-  matrix:
-    Python35:
-      python.version: '3.5'
-      TOXENV: py35
-    Python36:
-      python.version: '3.6'
-      TOXENV: py36
-    Python37:
-      python.version: '3.7'
-      TOXENV: py37
+jobs:
+    - job: 'Docs'
+      pool: {vmImage: 'ubuntu-16.04'}
+      strategy:
+        matrix:
+          Python37:
+            python.version: '3.7'
+      steps:
+       - checkout: self
+       - task: UsePythonVersion@0
+         inputs:
+           versionSpec: '$(python.version)'
+         displayName: 'Use Python $(python.version)'
+       - bash: |
+           set -e
+           python -m pip install --upgrade pip virtualenv
+           pip install -U tox
+           python setup.py build_ext --inplace
+         displayName: 'Install dependencies'
+       - bash: |
+           tox -edocs -- -j auto
+         displayName: 'Run Docs build'
+       - task: PublishBuildArtifacts@1
+         displayName: 'Publish docs'
+         inputs:
+           pathtoPublish: 'docs/_build/html'
+           artifactName: 'html_docs'
+    - job: 'windows'
+      pool:
+        vmImage: 'vs2017-win2016'
+      strategy:
+        matrix:
+          Python35:
+            python.version: '3.5'
+            TOXENV: py35
+          Python36:
+            python.version: '3.6'
+            TOXENV: py36
+          Python37:
+            python.version: '3.7'
+            TOXENV: py37
 
-steps:
-  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-    displayName: Add conda to PATH
-  - script: conda create --yes --quiet --name qiskit-ignis
-    displayName: Create Anaconda environment
-  - script: |
-      call activate qiskit-ignis
-      conda install --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION% mkl
-    displayName: Install Anaconda packages
-  - script: |
-      call activate qiskit-ignis
-      python -m pip install --upgrade pip virtualenv
-      pip install tox
-      tox -e%TOXENV%
-    displayName: 'Install dependencies and run tests'
+      steps:
+        - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+          displayName: Add conda to PATH
+        - script: conda create --yes --quiet --name qiskit-ignis
+          displayName: Create Anaconda environment
+        - script: |
+            call activate qiskit-ignis
+            conda install --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION% mkl
+          displayName: Install Anaconda packages
+        - script: |
+            call activate qiskit-ignis
+            python -m pip install --upgrade pip virtualenv
+            pip install tox
+            tox -e%TOXENV%
+          displayName: 'Install dependencies and run tests'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,3 +114,5 @@ html_theme = 'sphinx_rtd_theme'  # use the theme in subdir 'theme'
 
 html_sidebars = {'**': ['globaltoc.html']}
 html_last_updated_fmt = '%Y/%m/%d'
+
+autoclass_content = 'both'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ sphinx-tabs>=1.1.11
 sphinx-automodapi
 stestr>=2.5.0
 ddt>=1.2.0
+jupyter

--- a/tox.ini
+++ b/tox.ini
@@ -26,3 +26,9 @@ deps =
 commands =
   pycodestyle qiskit/ignis test/
   pylint -rn --rcfile={toxinidir}/.pylintrc qiskit/ignis test/
+
+[testenv:docs]
+deps =
+    -r{toxinidir}/requirements-dev.txt
+commands =
+  sphinx-build -b html docs/ docs/_build/html {posargs}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now there are no jobs that check that the sphinx build using the
ignis docstrings actually succeed. This commit adds an azure pipelines
job to run the docs build. Azure is used instead of travis because it
includes an artifacts store for output from the job which we can dump
the built output in after a successful run. This will enable people to
download it and view the output locally. Additionally, a tox job,
tox -edocs, is added so reproducing the docs builds locally is
straightforward.

### Details and comments


