### PR TITLE
Added circlabel in characterization

### DIFF
--- a/qiskit/ignis/characterization/coherence/circuits.py
+++ b/qiskit/ignis/characterization/coherence/circuits.py
@@ -21,7 +21,7 @@ import qiskit
 from ..characterization_utils import pad_id_gates
 
 
-def t1_circuits(num_of_gates, gate_time, qubits):
+def t1_circuits(num_of_gates, gate_time, qubits, circlabel=''):
     """
     Generates circuit for T1 measurement.
     Each circuit consists of an X gate, followed by a sequence of identity
@@ -33,11 +33,16 @@ def t1_circuits(num_of_gates, gate_time, qubits):
         gate_time (float): time of running a single gate.
         qubits (list of integers): indices of the qubits whose T1 are
             to be measured.
+        circlabel: A string to add to the front of circuit names for
+            unique identification.
 
     Returns:
        A list of QuantumCircuit
        xdata: a list of delay times
     """
+
+    if circlabel != '':
+        circlabel = circlabel + '-'
 
     xdata = gate_time * num_of_gates
 
@@ -48,7 +53,7 @@ def t1_circuits(num_of_gates, gate_time, qubits):
 
     for circ_index, circ_length in enumerate(num_of_gates):
         circ = qiskit.QuantumCircuit(qr, cr)
-        circ.name = 't1circuit_' + str(circ_index) + '_0'
+        circ.name = circlabel + 't1circuit_' + str(circ_index) + '_0'
         for _, qubit in enumerate(qubits):
             circ.x(qr[qubit])
             circ = pad_id_gates(circ, qr, qubit, circ_length)
@@ -60,7 +65,7 @@ def t1_circuits(num_of_gates, gate_time, qubits):
     return circuits, xdata
 
 
-def t2star_circuits(num_of_gates, gate_time, qubits, nosc=0):
+def t2star_circuits(num_of_gates, gate_time, qubits, nosc=0, circlabel=''):
     """
     Generates circuit for T2* measurement.
     Each circuit consists of a Hadamard gate, followed by a sequence of
@@ -74,11 +79,17 @@ def t2star_circuits(num_of_gates, gate_time, qubits, nosc=0):
         qubits (list of integers): indices of the qubits
             whose T2* are to be measured.
         nosc: number of oscillations to induce using the phase gate
+        circlabel: A string to add to the front of circuit names for
+            unique identification.
+
     Returns:
         A list of QuantumCircuit
         xdata: a list of delay times
         osc_freq: the induced oscillation frequency
     """
+
+    if circlabel != '':
+        circlabel = circlabel + '-'
 
     xdata = gate_time * num_of_gates
 
@@ -91,7 +102,7 @@ def t2star_circuits(num_of_gates, gate_time, qubits, nosc=0):
 
     for circ_index, circ_length in enumerate(num_of_gates):
         circ = qiskit.QuantumCircuit(qr, cr)
-        circ.name = 't2starcircuit_' + str(circ_index) + '_0'
+        circ.name = circlabel + 't2starcircuit_' + str(circ_index) + '_0'
         for qind, qubit in enumerate(qubits):
             circ.h(qr[qubit])
             circ = pad_id_gates(circ, qr, qubit, circ_length)
@@ -106,7 +117,7 @@ def t2star_circuits(num_of_gates, gate_time, qubits, nosc=0):
 
 
 def t2_circuits(num_of_gates, gate_time, qubits, n_echos=1,
-                phase_alt_echo=False):
+                phase_alt_echo=False, circlabel=''):
     """
     Generates circuit for T2 (echo) measurement, by a CPMG sequence.
     Each circuit consists of:
@@ -129,10 +140,16 @@ def t2_circuits(num_of_gates, gate_time, qubits, n_echos=1,
         n_echos (integer): number of echo gates (X or Y).
         phase_alt_echo (bool): if True then alternate the echo between
             X and Y.
+        circlabel: A string to add to the front of circuit names for
+            unique identification.
+
     Returns:
         A list of QuantumCircuit
         xdata: the delay times
     """
+
+    if circlabel != '':
+        circlabel = circlabel + '-'
 
     if n_echos < 1:
         raise ValueError('Must be at least one echo')
@@ -146,7 +163,7 @@ def t2_circuits(num_of_gates, gate_time, qubits, n_echos=1,
 
     for circ_index, circ_length in enumerate(num_of_gates):
         circ = qiskit.QuantumCircuit(qr, cr)
-        circ.name = 't2circuit_' + str(circ_index) + '_0'
+        circ.name = circlabel + 't2circuit_' + str(circ_index) + '_0'
         for qind, qubit in enumerate(qubits):
 
             # First Y90 and Y echo

--- a/qiskit/ignis/characterization/coherence/fitters.py
+++ b/qiskit/ignis/characterization/coherence/fitters.py
@@ -27,11 +27,15 @@ class T1Fitter(BaseCoherenceFitter):
     def __init__(self, backend_result, xdata,
                  qubits,
                  fit_p0, fit_bounds,
-                 time_unit='micro-seconds'):
+                 time_unit='micro-seconds',
+                 circlabel=''):
+
+        if circlabel != '':
+            circlabel = circlabel + '-'
 
         circuit_names = []
         for cind, _ in enumerate(xdata):
-            circuit_names.append('t1circuit_%d_' % cind)
+            circuit_names.append('%st1circuit_%d_' % (circlabel, cind))
 
         BaseCoherenceFitter.__init__(self, '$T_1$',
                                      backend_result, xdata,
@@ -57,11 +61,15 @@ class T2Fitter(BaseCoherenceFitter):
 
     def __init__(self, backend_result, xdata,
                  qubits, fit_p0, fit_bounds, circbasename='t2',
-                 time_unit='micro-seconds'):
+                 time_unit='micro-seconds',
+                 circlabel=''):
+
+        if circlabel != '':
+            circlabel = circlabel + '-'
 
         circuit_names = []
         for cind, _ in enumerate(xdata):
-            circuit_names.append('%scircuit_%d_' % (circbasename, cind))
+            circuit_names.append('%s%scircuit_%d_' % (circlabel, circbasename, cind))
 
         BaseCoherenceFitter.__init__(self, '$T_2$',
                                      backend_result,
@@ -87,11 +95,15 @@ class T2StarFitter(BaseCoherenceFitter):
 
     def __init__(self, backend_result, xdata,
                  qubits, fit_p0, fit_bounds,
-                 time_unit='micro-seconds'):
+                 time_unit='micro-seconds',
+                 circlabel=''):
+
+        if circlabel != '':
+            circlabel = circlabel + '-'
 
         circuit_names = []
         for cind, _ in enumerate(xdata):
-            circuit_names.append('t2starcircuit_%d_' % cind)
+            circuit_names.append('%st2starcircuit_%d_' % (circlabel, cind))
 
         BaseCoherenceFitter.__init__(self, '$T_2^*$',
                                      backend_result,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Measurement error mitigation has an option to add a prefix to circuit names, named `circlabel`. This allows to execute batches of circuits coming from different sources (e.g. different types of measurement mitigation) in the same job, while fitting them separately when the job is done. This pull request adds the same option to T1 and T2 characterization circuits.

### Details and comments

There is one difference between the handling of `circlabel` in measurement error mitigation and in this pull request. In measurement error mitigation, the circuit name always starts with `circlabel_`. This means that in the default case, when `circlabel` is the empty string, the circuit's name starts with an underscore. However in this pull request the underscore is appended to `circlabel` only if it is not an empty string. I prefer the measurement error mitigation version. The only reason that I don't do the same here is because it breaks tests that rely on pre-preapred pickled files, and I don't want to make the effort of generating new files. This indicates that our usage of pickled files in our tests is problematic; it requires too much effort to update the tests, even for small modifications in the code.
