### PR TITLE
Pin pywin32 version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
           displayName: Install Anaconda packages
         - script: |
             call activate qiskit-ignis
-            python -m pip install --upgrade pip virtualenv
-            pip install tox
+            python -m pip install -c constraints.txt --upgrade pip virtualenv
+            pip install -c constraints.txt tox
             tox -e%TOXENV%
           displayName: 'Install dependencies and run tests'

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 pylint==2.4.2
 astroid==2.3.1
+pywin32==225

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,8 @@ deps = numpy>=1.13
        Cython>=0.27.1
        setuptools>=40.1.0
 commands =
-    pip install -U git+https://github.com/Qiskit/qiskit-terra.git
-    pip install -U -r{toxinidir}/requirements-dev.txt
+    pip install -U -c constraints.txt git+https://github.com/Qiskit/qiskit-terra.git
+    pip install -U -c constraints.txt -r{toxinidir}/requirements-dev.txt
     stestr run {posargs}
 
 [testenv:lint]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Pywin32 was release on Nov. 10 and introduced an issue when running
virtualenv on windows, mhammond/pywin32#1439. This causes our ci system
to fail when trying to run the windows jobs because tox is uses
virtualenv underneath. This commit adds a pin via the constraints file
to ensure that we are installing the older version which does not have
this problem.

### Details and comments