### PR TITLE
Change default solver to CVXPY default for CVX tomography

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ test/python/*.pdf
 test/python/*.prof
 .stestr/
 
+# Built documentation
+docs/_build/
+docs/stubs/
+docs/api/
+
 # dotenv
 .env
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
     if [ ! "$(ls -A .stestr)" ]; then
         rm -r .stestr
     fi
-   - pip install --no-cache-dir ---ignore-installed scs
+   - pip install --no-cache-dir --ignore-installed scs
 
 stages:
  - lint_and_python

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ matrix:
 language: python
 install: pip install -U tox pip virtualenv
 script:
-  - tox
+  - tox --sitepackages
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
         - twine upload dist/qiskit*
 
 language: python
-install: pip install -U tox pip virtualenv
+install: pip install -U tox pip virtualenv setuptools
 script:
   - tox --sitepackages
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ language: python
 install: pip install -U tox pip virtualenv setuptools
 script:
   - tox --notest
-  - tox/$TOXENV/bin/pip install --no-cache-dir --ignore-installed scs
+  - .tox/$TOXENV/bin/pip install --no-cache-dir --ignore-installed scs
   - tox
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ before_script:
     if [ ! "$(ls -A .stestr)" ]; then
         rm -r .stestr
     fi
-   - pip install --no-cache-dir --ignore-installed scs
 
 stages:
  - lint_and_python
@@ -108,7 +107,9 @@ matrix:
 language: python
 install: pip install -U tox pip virtualenv setuptools
 script:
-  - tox --sitepackages
+  - tox --notest
+  - tox/$TOXENV/bin/pip install --no-cache-dir --ignore-installed scs
+  - tox
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ addons:
     packages:
       - gcc-4.8
       - g++-4.8
+      - libblas-dev
+      - liblapack-dev
 
 install_osx: &stage_osx
   os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_script:
     if [ ! "$(ls -A .stestr)" ]; then
         rm -r .stestr
     fi
+   - pip install --no-cache-dir ---ignore-installed scs
 
 stages:
  - lint_and_python

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,7 @@ jobs:
           Python35:
             python.version: '3.5'
             TOXENV: py35
+            OPENBLAS: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
           Python36:
             python.version: '3.6'
             TOXENV: py36
@@ -59,16 +60,19 @@ jobs:
             conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% scs
           displayName: Install Anaconda packages
           condition: ne(variables['python.version'], '3.5')
-        - script: |
-            call activate qiskit-ignis
-            conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% openblas
+        - ps: (new-object System.Net.WebClient).DownloadFile($env:OPENBLAS, 'c:\openblas.zip')
+          condition: eq(variables['python.version'], '3.5')
+        - ps: Expand-Archive c:\openblas.zip c:\openblas
           condition: eq(variables['python.version'], '3.5')
         - script: |
             call activate qiskit-ignis
+            set PATH=%PATH%;%BINPATH%;C:\projects\openblas\%64%\bin;
+            echo %PATH%
+            dir C:\openblas\%ARCH%\bin
             git clone https://github.com/cvxgrp/scs.git
             cd scs
             git checkout 2.1.1
-            make.exe CC="gcc.exe" USE_LAPACK=1
+            make.exe CC="gcc.exe -m64" USE_LAPACK=1 BLASLDFLAGS="-LC:\openblas\64\bin -lopenblas_5f998ef_gcc7_1_0"
             make.exe install
             cd ..
           condition: eq(variables['python.version'], '3.5')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
       steps:
         - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
           displayName: Add conda to PATH
-        - script: conda create --yes --quiet --name qiskit-ignis
+        - script: conda create --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION%
           displayName: Create Anaconda environment
         - script: |
             call activate qiskit-ignis
@@ -62,8 +62,10 @@ jobs:
           condition: ne(variables['python.version'], '3.5')
         - powershell: (new-object System.Net.WebClient).DownloadFile($env:OPENBLAS, 'c:\openblas.zip')
           condition: eq(variables['python.version'], '3.5')
+          displayName: 'Download openblas'
         - powershell: Expand-Archive c:\openblas.zip c:\openblas
           condition: eq(variables['python.version'], '3.5')
+          displayName: 'Unzip openblas'
         - script: |
             call activate qiskit-ignis
             set PATH=%PATH%;%BINPATH%;C:\openblas\%64%\bin;
@@ -77,6 +79,10 @@ jobs:
             cd ..
           condition: eq(variables['python.version'], '3.5')
           displayName: 'Install scs from source for python 3.5'
+        - script: |
+            call activate qiskit-ignis
+            conda install --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION% mkl
+          displayName: 'Install MKL'
         - script: |
             call activate qiskit-ignis
             python -m pip install -c constraints.txt --upgrade pip virtualenv

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,18 @@ jobs:
             call activate qiskit-ignis
             conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% scs
           displayName: Install Anaconda packages
+          condition: ne(variables['python.version'], '3.5')
+        - script: |
+            call activate qiskit-ignis
+            conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% openblas
+            git clone https://github.com/cvxgrp/scs.git
+            cd scs
+            git checkout 2.1.1
+            make.exe CC="gcc.exe" USE_LAPACK=1
+            make.exe install
+            cd ..
+          condition: eq(variables['python.version'], '3.5')
+          displayName: 'Install scs from source for python 3.5'
         - script: |
             call activate qiskit-ignis
             python -m pip install -c constraints.txt --upgrade pip virtualenv

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,9 @@ jobs:
         - script: |
             call activate qiskit-ignis
             conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% openblas
+          condition: eq(variables['python.version'], '3.5')
+        - script: |
+            call activate qiskit-ignis
             git clone https://github.com/cvxgrp/scs.git
             cd scs
             git checkout 2.1.1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
           displayName: Create Anaconda environment
         - script: |
             call activate qiskit-ignis
-            conda install --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION% mkl
+            conda install --yes --quiet --name qiskit-ignis -c cvxgrp python=%PYTHON_VERSION% cvxpy
           displayName: Install Anaconda packages
         - script: |
             call activate qiskit-ignis

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,13 +60,13 @@ jobs:
             conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% scs
           displayName: Install Anaconda packages
           condition: ne(variables['python.version'], '3.5')
-        - ps: (new-object System.Net.WebClient).DownloadFile($env:OPENBLAS, 'c:\openblas.zip')
+        - powershell: (new-object System.Net.WebClient).DownloadFile($env:OPENBLAS, 'c:\openblas.zip')
           condition: eq(variables['python.version'], '3.5')
-        - ps: Expand-Archive c:\openblas.zip c:\openblas
+        - powershell: Expand-Archive c:\openblas.zip c:\openblas
           condition: eq(variables['python.version'], '3.5')
         - script: |
             call activate qiskit-ignis
-            set PATH=%PATH%;%BINPATH%;C:\projects\openblas\%64%\bin;
+            set PATH=%PATH%;%BINPATH%;C:\openblas\%64%\bin;
             echo %PATH%
             dir C:\openblas\%ARCH%\bin
             git clone https://github.com/cvxgrp/scs.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,14 +68,19 @@ jobs:
           displayName: 'Unzip openblas'
         - script: |
             call activate qiskit-ignis
+            conda install --yes --quiet --update-all --name qiskit-ignis python=%PYTHON_VERSION% numpy scipy
+          displayName: Install Anaconda packages
+          condition: eq(variables['python.version'], '3.5')
+        - script: |
+            call activate qiskit-ignis
             set PATH=%PATH%;%BINPATH%;C:\openblas\%64%\bin;
             echo %PATH%
             dir C:\openblas\%ARCH%\bin
-            git clone https://github.com/cvxgrp/scs.git
-            cd scs
-            git checkout 2.1.1
             make.exe CC="gcc.exe -m64" USE_LAPACK=1 BLASLDFLAGS="-LC:\openblas\64\bin -lopenblas_5f998ef_gcc7_1_0"
             make.exe install
+            git clone --recursive https://github.com/bodono/scs-python.git
+            cd scs-python
+            python setup.py install --scs 'CC="gcc.exe -m64" USE_LAPACK=1 BLASLDFLAGS="-LC:\openblas\64\bin -lopenblas_5f998ef_gcc7_1_0"'
             cd ..
           condition: eq(variables['python.version'], '3.5')
           displayName: 'Install scs from source for python 3.5'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,5 +62,5 @@ jobs:
             call activate qiskit-ignis
             python -m pip install -c constraints.txt --upgrade pip virtualenv
             pip install -c constraints.txt tox
-            tox -e%TOXENV%
+            tox --sitepackages -e%TOXENV%
           displayName: 'Install dependencies and run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
           displayName: Create Anaconda environment
         - script: |
             call activate qiskit-ignis
-            conda install --yes --quiet --name qiskit-ignis --channel cvxgrp python=%PYTHON_VERSION% cvxpy
+            conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% scs
           displayName: Install Anaconda packages
         - script: |
             call activate qiskit-ignis

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
           displayName: Create Anaconda environment
         - script: |
             call activate qiskit-ignis
-            conda install --yes --quiet --name qiskit-ignis -c cvxgrp python=%PYTHON_VERSION% cvxpy
+            conda install --yes --quiet --name qiskit-ignis --channel cvxgrp python=%PYTHON_VERSION% cvxpy
           displayName: Install Anaconda packages
         - script: |
             call activate qiskit-ignis

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,7 @@ jobs:
           displayName: 'Install MKL'
         - script: |
             call activate qiskit-ignis
-            python -m pip install -c constraints.txt --upgrade pip virtualenv
-            pip install -c constraints.txt tox
+            python -m pip install -c constraints.txt --upgrade pip virtualenv setuptools
+            pip install -c constraints.txt -U tox
             tox --sitepackages -e%TOXENV%
           displayName: 'Install dependencies and run tests'

--- a/qiskit/ignis/verification/tomography/fitters/base_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/base_fitter.py
@@ -99,7 +99,7 @@ class TomographyFitter:
         return self._prep_basis
 
     def fit(self, method='auto', standard_weights=True, beta=0.5, **kwargs):
-        """Reconstruct a quantum state using CVXPY convex optimization.
+        r"""Reconstruct a quantum state using CVXPY convex optimization.
 
                 **Fitter method**
 
@@ -116,13 +116,14 @@ class TomographyFitter:
         subject to:
 
          * :math:`x >> 0`
-         * :math:`trace(x) = 1`
+         * :math:`\text{trace}(x) = 1`
 
         where:
 
-         * a is the matrix of measurement operators :math:`a[i] = vec(M_i).H`
+         * a is the matrix of measurement operators
+           :math:`a[i] = \text{vec}(M_i).H`
          * b is the vector of expectation value data for each projector
-           :math:`b[i] ~ Tr[M_i.H * x] = (a * x)[i]`
+           :math:`b[i] ~ \text{Tr}[M_i.H * x] = (a * x)[i]`
          * x is the vectorized density matrix to be fitted
 
         **PSD constraint**
@@ -145,13 +146,9 @@ class TomographyFitter:
         **CVXPY Solvers:**
 
         Various solvers can be called in CVXPY using the `solver` keyword
-        argument. Solvers included in CVXPY are:
-
-         * ``CVXOPT``: SDP and SOCP (default solver)
-         * ``SCS``: SDP and SOCP
-         * ``ECOS``: SOCP only
-
-        See the documentation on CVXPY for more information on solvers.
+        argument. See the `CVXPY documentation
+        <https://www.cvxpy.org/tutorial/advanced/index.html#solve-method-options>`_
+        for more information on solvers.
 
         References:
 

--- a/qiskit/ignis/verification/tomography/fitters/cvx_fit.py
+++ b/qiskit/ignis/verification/tomography/fitters/cvx_fit.py
@@ -29,8 +29,55 @@ except ImportError:
 
 def cvx_fit(data, basis_matrix, weights=None, PSD=True, trace=None,
             trace_preserving=False, **kwargs):
-    """
+    r"""
     Reconstruct a quantum state using CVXPY convex optimization.
+
+    **Objective function**
+
+    This fitter solves the constrained least-squares minimization:
+    :math:`minimize: ||a * x - b ||_2`
+
+    subject to:
+
+    * :math:`x >> 0` (PSD, optional)
+    * :math:`\text{trace}(x) = t` (trace, optional)
+    * :math:`\text{partial_trace}(x)` = identity (trace_preserving, optional)
+
+    where:
+    * a is the matrix of measurement operators :math:`a[i] = vec(M_i).H`
+    * b is the vector of expectation value data for each projector
+      :math:`b[i] ~ \text{Tr}[M_i.H * x] = (a * x)[i]`
+    * x is the vectorized density matrix (or Choi-matrix) to be fitted
+
+    **PSD constraint**
+
+    The PSD keyword constrains the fitted matrix to be
+    postive-semidefinite, which makes the optimization problem a SDP. If
+    PSD=False the fitted matrix will still be constrained to be Hermitian,
+    but not PSD. In this case the optimization problem becomes a SOCP.
+
+    **Trace constraint**
+
+    The trace keyword constrains the trace of the fitted matrix. If
+    trace=None there will be no trace constraint on the fitted matrix.
+    This constraint should not be used for process tomography and the
+    trace preserving constraint should be used instead.
+
+    **Trace preserving (TP) constraint**
+
+    The trace_preserving keyword constrains the fitted matrix to be TP.
+    This should only be used for process tomography, not state tomography.
+    Note that the TP constraint implicitly enforces the trace of the fitted
+    matrix to be equal to the square-root of the matrix dimension. If a
+    trace constraint is also specified that differs from this value the fit
+    will likely fail.
+
+    **CVXPY Solvers**
+
+    Various solvers can be called in CVXPY using the `solver` keyword
+    argument. See the `CVXPY documentation
+    <https://www.cvxpy.org/tutorial/advanced/index.html#solve-method-options>`_
+    for more information on solvers.
 
     Args:
         data (vector like): vector of expectation values
@@ -48,57 +95,7 @@ def cvx_fit(data, basis_matrix, weights=None, PSD=True, trace=None,
 
     Returns:
         The fitted matrix rho that minimizes
-        ||basis_matrix * vec(rho) - data||_2.
-
-    Additional Information:
-
-        Objective function
-        ------------------
-        This fitter solves the constrained least-squares minimization:
-
-            minimize: ||a * x - b ||_2
-            subject to: x >> 0 (PSD, optional)
-                        trace(x) = t (trace, optional)
-                        partial_trace(x) = identity (trace_preserving,
-                                                     optional)
-
-        where:
-            a is the matrix of measurement operators a[i] = vec(M_i).H
-            b is the vector of expectation value data for each projector
-              b[i] ~ Tr[M_i.H * x] = (a * x)[i]
-            x is the vectorized density matrix (or Choi-matrix) to be fitted
-
-        PSD constraint
-        --------------
-        The PSD keyword constrains the fitted matrix to be
-        postive-semidefinite, which makes the optimization problem a SDP. If
-        PSD=False the fitted matrix will still be constrained to be Hermitian,
-        but not PSD. In this case the optimization problem becomes a SOCP.
-
-        Trace constraint
-        ----------------
-        The trace keyword constrains the trace of the fitted matrix. If
-        trace=None there will be no trace constraint on the fitted matrix.
-        This constraint should not be used for process tomography and the
-        trace preserving constraint should be used instead.
-
-        Trace preserving (TP) constraint
-        --------------------------------
-        The trace_preserving keyword constrains the fitted matrix to be TP.
-        This should only be used for process tomography, not state tomography.
-        Note that the TP constraint implicitly enforces the trace of the fitted
-        matrix to be equal to the square-root of the matrix dimension. If a
-        trace constraint is also specified that differs from this value the fit
-        will likely fail.
-
-        CVXPY Solvers:
-        -------
-        Various solvers can be called in CVXPY using the `solver` keyword
-        argument. Solvers included in CVXPY are:
-            'CVXOPT': SDP and SOCP (default solver)
-            'SCS'   : SDP and SOCP
-            'ECOS'  : SOCP only
-        See the documentation on CVXPY for more information on solvers.
+            :math:`||basis_matrix * vec(rho) - data||_2`.
     """
 
     # Check if CVXPY package is installed
@@ -194,10 +191,6 @@ def cvx_fit(data, basis_matrix, weights=None, PSD=True, trace=None,
     prob = cvxpy.Problem(obj, cons)
     iters = 5000
     max_iters = kwargs.get('max_iters', 20000)
-
-    # Set the default solver to 'CVXOPT'
-    if 'solver' not in kwargs:
-        kwargs['solver'] = 'CVXOPT'
 
     problem_solved = False
     while not problem_solved:

--- a/qiskit/ignis/verification/tomography/fitters/process_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/process_fitter.py
@@ -29,7 +29,7 @@ class ProcessTomographyFitter(TomographyFitter):
     """Maximum-Likelihood estimation process tomography fitter."""
 
     def fit(self, method='auto', standard_weights=True, beta=0.5, **kwargs):
-        """Reconstruct a quantum channel using CVXPY convex optimization.
+        r"""Reconstruct a quantum channel using CVXPY convex optimization.
 
         **Choi matrix**
 
@@ -54,14 +54,15 @@ class ProcessTomographyFitter(TomographyFitter):
         subject to:
 
          * :math:`x >> 0` (PSD)
-         * :math:`trace(x) = dim` (trace)
-         * :math:`partial_trace(x) = identity` (trace_preserving)
+         * :math:`\text{trace}(x) = dim` (trace)
+         * :math:`\text{partial_trace}(x) = \text{identity}` (trace_preserving)
 
         where:
 
-         * a is the matrix of measurement operators :math:`a[i] = vec(M_i).H`
+         * a is the matrix of measurement operators
+           :math:`a[i] = \text{vec}(M_i).H`
          * b is the vector of expectation value data for each projector
-           :math:`b[i] ~ Tr[M_i.H * x] = (a * x)[i]`
+           :math:`b[i] ~ \text{Tr}[M_i.H * x] = (a * x)[i]`
          * x is the vectorized Choi-matrix to be fitted
 
         **PSD constraint**
@@ -93,13 +94,9 @@ class ProcessTomographyFitter(TomographyFitter):
         **CVXPY Solvers:**
 
         Various solvers can be called in CVXPY using the `solver` keyword
-        argument. Solvers included in CVXPY are:
-
-         * ``CVXOPT``: SDP and SOCP (default solver)
-         * ``SCS``: SDP and SOCP
-         * ``ECOS``: SOCP only
-
-        See the documentation on CVXPY for more information on solvers.
+        argument. See the `CVXPY documentation
+        <https://www.cvxpy.org/tutorial/advanced/index.html#solve-method-options>`_
+        for more information on solvers.
 
         References:
 

--- a/qiskit/ignis/verification/tomography/fitters/state_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/state_fitter.py
@@ -41,7 +41,7 @@ class StateTomographyFitter(TomographyFitter):
         super().__init__(result, circuits, meas_basis, None)
 
     def fit(self, method='auto', standard_weights=True, beta=0.5, **kwargs):
-        """Reconstruct a quantum state using CVXPY convex optimization.
+        r"""Reconstruct a quantum state using CVXPY convex optimization.
 
         **Fitter method**
 
@@ -58,13 +58,14 @@ class StateTomographyFitter(TomographyFitter):
         subject to:
 
          * :math:`x >> 0`
-         * :math:`trace(x) = 1`
+         * :math:`\text{trace}(x) = 1`
 
         where:
 
-         * a is the matrix of measurement operators :math:`a[i] = vec(M_i).H`
+         * a is the matrix of measurement operators
+           :math:`a[i] = \text{vec}(M_i).H`
          * b is the vector of expectation value data for each projector
-           :math:`b[i] ~ Tr[M_i.H * x] = (a * x)[i]`
+           :math:`b[i] ~ \text{Tr}[M_i.H * x] = (a * x)[i]`
          * x is the vectorized density matrix to be fitted
 
         **PSD constraint**
@@ -87,13 +88,9 @@ class StateTomographyFitter(TomographyFitter):
         **CVXPY Solvers:**
 
         Various solvers can be called in CVXPY using the `solver` keyword
-        argument. Solvers included in CVXPY are:
-
-         * ``CVXOPT``: SDP and SOCP (default solver)
-         * ``SCS``: SDP and SOCP
-         * ``ECOS``: SOCP only
-
-        See the documentation on CVXPY for more information on solvers.
+        argument. See the `CVXPY documentation
+        <https://www.cvxpy.org/tutorial/advanced/index.html#solve-method-options>`_
+        for more information on solvers.
 
         References:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 cvxpy>=1.0.15
-cvxopt>=1.2.3
 qiskit-aer>=0.1.1
 scikit-learn>=0.17
 Sphinx>=1.8.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changes default solver method for CXV tomography from `CVXOPT` to whatever is the default solver used by CVXPY.

Updates tomography API documentation to fix rendering of math equations.

### Details and comments

Co-authored-by: Matthew Treinish <mtreinish@kortar.org>
