### PR TITLE
Fix FC rotation direction in u gate update function

### DIFF
--- a/qiskit/ignis/characterization/calibrations/ibmq_utils.py
+++ b/qiskit/ignis/characterization/calibrations/ibmq_utils.py
@@ -140,9 +140,9 @@ def update_u_gates(drag_params, pi2_pulse_schedules=None,
         else:
             _u2_group = (drive_ch, )
 
-        u2_fc1s = [parametrized_fc('P1', np.pi/2, ch, 0)
+        u2_fc1s = [parametrized_fc('P1', -np.pi/2, ch, 0)
                    for ch in _u2_group]
-        u2_fc2s = [parametrized_fc('P0', -np.pi/2, ch, pulse_dur)
+        u2_fc2s = [parametrized_fc('P0', np.pi/2, ch, pulse_dur)
                    for ch in _u2_group]
 
         # find channel dependency for u2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix #301 


### Details and comments
`Y90p = exp(-1j*pi/2)*X90p*exp(1j*pi/2)`. Y90p pulses are generated by clockwise pi/2 rotation from X90p pulse, yielding Y90***p*** comprises negative values.