### PR TITLE
Modified T1 circuits to not be aware of the physical qubits

### DIFF
--- a/qiskit/ignis/characterization/coherence/circuits.py
+++ b/qiskit/ignis/characterization/coherence/circuits.py
@@ -21,7 +21,7 @@ import qiskit
 from ..characterization_utils import pad_id_gates
 
 
-def t1_circuits(num_of_gates, gate_time, qubits):
+def t1_circuits(num_of_gates, gate_time, nqubits):
     """
     Generates circuit for T1 measurement.
     Each circuit consists of an X gate, followed by a sequence of identity
@@ -31,30 +31,33 @@ def t1_circuits(num_of_gates, gate_time, qubits):
         num_of_gates (list of integers): the number of identity gates in each
             circuit. Must be in an increasing order.
         gate_time (float): time of running a single gate.
-        qubits (list of integers): indices of the qubits whose T1 are
-            to be measured.
+                           Assuming that it is the same for all the qubits
+                           whose T1s are to be measured.
+        nqubits (integer): number of qubits whose T1s are to be measured.
+                           Specify which qubits in the `initial_layout`
+                           parameter when calling `execute`.
 
     Returns:
        A list of QuantumCircuit
-       xdata: a list of delay times
+       A list of delay times
     """
 
     xdata = gate_time * num_of_gates
 
-    qr = qiskit.QuantumRegister(max(qubits)+1)
-    cr = qiskit.ClassicalRegister(len(qubits))
+    qr = qiskit.QuantumRegister(nqubits)
+    cr = qiskit.ClassicalRegister(nqubits)
 
     circuits = []
 
     for circ_index, circ_length in enumerate(num_of_gates):
         circ = qiskit.QuantumCircuit(qr, cr)
         circ.name = 't1circuit_' + str(circ_index) + '_0'
-        for _, qubit in enumerate(qubits):
+        for qubit in range(nqubits):
             circ.x(qr[qubit])
             circ = pad_id_gates(circ, qr, qubit, circ_length)
         circ.barrier(qr)
-        for qind, qubit in enumerate(qubits):
-            circ.measure(qr[qubit], cr[qind])
+        for qubit in range(nqubits):
+            circ.measure(qr[qubit], cr[qubit])
         circuits.append(circ)
 
     return circuits, xdata

--- a/test/characterization/test_characterization.py
+++ b/test/characterization/test_characterization.py
@@ -132,7 +132,7 @@ class TestT1(unittest.TestCase):
 
     def test_t1(self):
         """
-        Run the simulator with thermal relaxatoin noise.
+        Run the simulator with thermal relaxation noise.
         Then verify that the calculated T1 matches the t1
         parameter.
         """
@@ -142,7 +142,7 @@ class TestT1(unittest.TestCase):
         gate_time = 0.11
         qubits = [0]
 
-        circs, xdata = t1_circuits(num_of_gates, gate_time, qubits)
+        circs, xdata = t1_circuits(num_of_gates, gate_time, len(qubits))
 
         expected_t1 = 10
         error = thermal_relaxation_error(expected_t1, 2*expected_t1, gate_time)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Circuits generations in Ignis contain the following line:
```
qr = qiskit.QuantumRegister(max(qubits)+1)
```

The logic of this line: since the circuit does contain CNOT gates, it is guaranteed, in the default optimization level of 1, that the virtual qubits `0, ..., max(qubits)` will be mapped to the same physical qubits.

It makes more sense to guarantee correct mapping by using the `initial_layout` parameter in `execute`. This way, the quantum register does not contain qubits that are not characterized and may cause cross-talk. This was not done before because something was wrong with `initial_layout`. This has been fixed in Terra, therefore this pull request updates Ignis accordingly.


### Details and comments

The update is for T1 only. If this pull request is OK, then its merge will be followed by a fix of other characterizations, randomized benchmarking, and measurement mitigation.

More urgently, need to correct the relevant tutorial notebook(s) right after the merge.
