### PR TITLE
Plotting of missclassified points

### DIFF
--- a/qiskit/ignis/measurement/discriminator/iq_discriminators.py
+++ b/qiskit/ignis/measurement/discriminator/iq_discriminators.py
@@ -288,7 +288,7 @@ class IQDiscriminationFitter(BaseDiscriminationFitter):
                         misclassified = x_data[y_disc != y_data]
                         ax.scatter(misclassified[:, q_idx],
                                    misclassified[:, n_qubits + q_idx],
-                                   color='r', alpha=0.5)
+                                   color='r', alpha=0.5, marker='x')
 
                 ax.legend(frameon=True)
 


### PR DESCRIPTION
### Summary
The discriminator plot can flag misclassified points.
It currently does this with circle markers.

### Details and comments
It is easier to read the misclassified IQ data shots when they are flagged with a cross.

