### PR TITLE
Make barriers in repetition code optional

### DIFF
--- a/qiskit/ignis/verification/topological_codes/circuits.py
+++ b/qiskit/ignis/verification/topological_codes/circuits.py
@@ -75,17 +75,19 @@ class RepetitionCode():
         circuit_list = [self.circuit[log] for log in ['0', '1']]
         return circuit_list
 
-    def x(self, logs=('0', '1')):
+    def x(self, logs=('0', '1'), barrier=False):
         """
         Applies a logical x to the circuits for the given logical values.
 
         Args:
             logs: List or tuple of logical values expressed as strings.
+            barrier: Boolean denoting whether to include a barrier at the end.
         """
         for log in logs:
             for j in range(self.d):
                 self.circuit[log].x(self.code_qubit[j])
-            self.circuit[log].barrier()
+            if barrier:
+                self.circuit[log].barrier()
 
     def _preparation(self):
         """
@@ -95,8 +97,12 @@ class RepetitionCode():
         self.x(['1'])
 
     def syndrome_measurement(self, reset=True):
-        """Application of a syndrome measurement round."""
+        """
+        Application of a syndrome measurement round.
 
+        Args:
+            barrier: Boolean denoting whether to include a barrier at the end.
+        """
         self.link_bits.append(ClassicalRegister(
             (self.d - 1), 'round_' + str(self.T) + '_link_bit'))
 
@@ -117,7 +123,8 @@ class RepetitionCode():
                 if reset:
                     self.circuit[log].reset(self.link_qubit[j])
 
-            self.circuit[log].barrier()
+            if barrier:
+                self.circuit[log].barrier()
 
         self.T += 1
 

--- a/qiskit/ignis/verification/topological_codes/circuits.py
+++ b/qiskit/ignis/verification/topological_codes/circuits.py
@@ -96,7 +96,7 @@ class RepetitionCode():
         """
         self.x(['1'])
 
-    def syndrome_measurement(self, reset=True):
+    def syndrome_measurement(self, reset=True, barrier=False):
         """
         Application of a syndrome measurement round.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The circuits for the `RepetitionCode` class have barriers, but only for cosmetic reasons. They were making the compiler complain, so they have to go! (except when someone uses `barrier=True`).

### Details and comments


