### PR TITLE
Fix a bug that caused the RB test to fail

### DIFF
--- a/qiskit/ignis/verification/randomized_benchmarking/clifford_utils.py
+++ b/qiskit/ignis/verification/randomized_benchmarking/clifford_utils.py
@@ -382,7 +382,7 @@ class CliffordUtils(BasicUtils):
                     picklefile='cliffords%d.pickle' % num_qubits)
             except pickle.UnpicklingError:
                 # handle error
-                clifford_tables = self.self.clifford2_gates_table()
+                clifford_tables = self.clifford2_gates_table()
 
         else:
             raise ValueError("The number of qubits should be only 1 or 2")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix a small typo that cause the rb tests to fail, when handling an exception when the group tables are generated.

### Details and comments
Thanks @gadial for finding this bug!

