### PR TITLE
Set a consistent line length to 100 characters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,3 +35,6 @@ deps =
     qiskit-ibmq-provider
 commands =
   sphinx-build -b html -W {posargs} docs/ docs/_build/html
+
+[pycodestyle]
+max-line-length = 100


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the pycodestyle rules used to match what is set in
pylint. Previously pycodesytle was using the default settings which has
an 80 character line length, but we set pylint to have a limit of 100.
This updates the pycodestyle configuration (via the tox.ini) to also
use 100 so they're consistent.

### Details and comments