### PR TITLE
Update ignis to be compatible with terra master

### DIFF
--- a/qiskit/ignis/characterization/calibrations/ibmq_utils.py
+++ b/qiskit/ignis/characterization/calibrations/ibmq_utils.py
@@ -96,7 +96,7 @@ def get_single_q_pulse(cmd_def, qubits):
 
 
 def update_u_gates(drag_params, pi2_pulse_schedules=None,
-                   qubits=None, cmd_def=None, drives=None):
+                   qubits=None, inst_map=None, cmd_def=None, drives=None):
     """
     Update the cmd_def with new single qubit gate values
     Will update U2, U3
@@ -105,7 +105,9 @@ def update_u_gates(drag_params, pi2_pulse_schedules=None,
         pi2_pulse_schedules: list of new pi/2 gate as a pulse schedule
         will use the drag_params if this is None
         qubits: list of qubits to update
-        cmd_def: CmdDef object for the device
+        inst_map: InstructionScheduleMap providing circuit instruction to
+                  schedule definitions.
+        cmd_def: CmdDef object for the device (deprecated)
         drives: List of drive chs
     Returns:
         updated cmd_def
@@ -113,6 +115,9 @@ def update_u_gates(drag_params, pi2_pulse_schedules=None,
 
     # U2 is -P1.Y90p.-P0
     # U3 is -P2.X90p.-P0.X90m.-P1
+
+    if cmd_def and not inst_map:
+        inst_map = cmd_def
 
     def parametrized_fc(kw_name, phi0, chan, t_offset):
         def _parametrized_fc(**kwargs):
@@ -134,7 +139,7 @@ def update_u_gates(drag_params, pi2_pulse_schedules=None,
         # find channel dependency for u2
         for _u2_group in _find_channel_groups('u2',
                                               qubits=qubit,
-                                              cmd_def=cmd_def):
+                                              inst_map=inst_map):
             if drive_ch in _u2_group:
                 break
         else:
@@ -148,7 +153,7 @@ def update_u_gates(drag_params, pi2_pulse_schedules=None,
         # find channel dependency for u2
         for _u3_group in _find_channel_groups('u3',
                                               qubits=qubit,
-                                              cmd_def=cmd_def):
+                                              inst_map=inst_map):
             if drive_ch in _u3_group:
                 break
         else:
@@ -177,22 +182,24 @@ def update_u_gates(drag_params, pi2_pulse_schedules=None,
                                           parameters=['P0', 'P1', 'P2'],
                                           name='u3_%d' % qubit)
 
-        cmd_def.add(cmd_name='u2', qubits=qubit, schedule=schedule1)
-        cmd_def.add(cmd_name='u3', qubits=qubit, schedule=schedule2)
+        inst_map.add('u2', qubits=qubit, schedule=schedule1)
+        inst_map.add('u3', qubits=qubit, schedule=schedule2)
 
 
-def _find_channel_groups(command, qubits, cmd_def):
+def _find_channel_groups(command, qubits, inst_map):
     """
     Extract frame dependency of control channel on drive channel.
 
     Args:
         command: name of command.
         qubits: target qubit index.
+        inst_map: InstructionScheduleMap providing circuit instruction to
+                  schedule definitions.
     Returns:
         channel_groups: group of channels in the same frame.
     """
-    params = cmd_def.get_parameters(command, qubits=qubits)
-    temp_sched = cmd_def.get(command, qubits=qubits,
+    params = inst_map.get_parameters(command, qubits=qubits)
+    temp_sched = inst_map.get(command, qubits=qubits,
                              **dict(zip(params, np.zeros(len(params)))))
 
     synced_fcs = defaultdict(list)

--- a/qiskit/ignis/characterization/calibrations/ibmq_utils.py
+++ b/qiskit/ignis/characterization/calibrations/ibmq_utils.py
@@ -200,7 +200,7 @@ def _find_channel_groups(command, qubits, inst_map):
     """
     params = inst_map.get_parameters(command, qubits=qubits)
     temp_sched = inst_map.get(command, qubits=qubits,
-                             **dict(zip(params, np.zeros(len(params)))))
+                              **dict(zip(params, np.zeros(len(params)))))
 
     synced_fcs = defaultdict(list)
     for t0, inst in temp_sched.instructions:

--- a/qiskit/ignis/characterization/calibrations/pulse_schedules.py
+++ b/qiskit/ignis/characterization/calibrations/pulse_schedules.py
@@ -26,7 +26,7 @@ from qiskit.scheduler import schedule_circuit, ScheduleConfig
 
 def rabi_schedules(amp_list, qubits, pulse_width, pulse_sigma=None,
                    width_sigma_ratio=4, drives=None, cmd_def=None,
-                   meas_map=None):
+                   inst_map=None, meas_map=None):
     """
     Generates schedules for a rabi experiment using a Gaussian pulse
 
@@ -39,7 +39,8 @@ def rabi_schedules(amp_list, qubits, pulse_width, pulse_sigma=None,
         width_sigma_ratio: set sigma to a certain ratio of the width (use if
         pulse_sigma is None)
         drives: list of DriveChannel objects
-        cmd_def: CmdDef object to use
+        cmd_def: CmdDef object to use (deprecated)
+        inst_map: InstructionScheduleMap object to use
         meas_map: meas_map to use
 
     Returns:
@@ -49,8 +50,10 @@ def rabi_schedules(amp_list, qubits, pulse_width, pulse_sigma=None,
 
     xdata = amp_list
 
-    # copy the command def
-    cmd_def = copy.deepcopy(cmd_def)
+    # copy the instruction to schedule mapping
+    inst_map = copy.deepcopy(inst_map)
+    if not inst_map:
+        inst_map = copy.deepcopy(cmd_def)
 
     if pulse_sigma is None:
         pulse_sigma = pulse_width / width_sigma_ratio
@@ -81,9 +84,9 @@ def rabi_schedules(amp_list, qubits, pulse_width, pulse_sigma=None,
 
             schedule += rabi_pulse(drives[qubit])
 
-            # append this schedule to the cmd_def
-            cmd_def.add('rabi_%d' % circ_index, qubits=[qubit],
-                        schedule=schedule)
+            # append this schedule to the inst_map
+            inst_map.add('rabi_%d' % circ_index, qubits=[qubit],
+                         schedule=schedule)
 
             circ.append(rabi_gate, [qr[qubit]])
 
@@ -93,7 +96,7 @@ def rabi_schedules(amp_list, qubits, pulse_width, pulse_sigma=None,
         circuits.append(circ)
 
         # schedule
-        schedule_config = ScheduleConfig(cmd_def, meas_map)
+        schedule_config = ScheduleConfig(inst_map, meas_map)
         rabi_sched = [schedule_circuit(qcirc,
                                        schedule_config)
                       for qcirc in circuits]
@@ -104,7 +107,7 @@ def rabi_schedules(amp_list, qubits, pulse_width, pulse_sigma=None,
 def drag_schedules(beta_list, qubits, pulse_amp, pulse_width,
                    pulse_sigma=None,
                    width_sigma_ratio=4, drives=None, cmd_def=None,
-                   meas_map=None):
+                   inst_map=None, meas_map=None):
     """
     Generates schedules for a drag experiment doing a pulse then
     the - pulse
@@ -119,7 +122,8 @@ def drag_schedules(beta_list, qubits, pulse_amp, pulse_width,
         width_sigma_ratio: set sigma to a certain ratio of the width (use if
         pulse_sigma is None)
         drives: list of DriveChannel objects
-        cmd_def: CmdDef object to use
+        cmd_def: CmdDef object to use (deprecated)
+        inst_map: InstructionScheduleMap object to use
         meas_map: meas_map to use
 
     Returns:
@@ -129,8 +133,10 @@ def drag_schedules(beta_list, qubits, pulse_amp, pulse_width,
 
     xdata = beta_list
 
-    # copy the command def
-    cmd_def = copy.deepcopy(cmd_def)
+    # copy the instruction to schedule mapping
+    inst_map = copy.deepcopy(inst_map)
+    if not inst_map:
+        inst_map = copy.deepcopy(cmd_def)
 
     if pulse_sigma is None:
         pulse_sigma = pulse_width / width_sigma_ratio
@@ -165,9 +171,9 @@ def drag_schedules(beta_list, qubits, pulse_amp, pulse_width,
 
             schedule += drag_pulse(drives[qubit])
 
-            # append this schedule to the cmd_def
-            cmd_def.add('drag_%d_%d' % (circ_index, qubit), qubits=[qubit],
-                        schedule=schedule)
+            # append this schedule to the inst_map
+            inst_map.add('drag_%d_%d' % (circ_index, qubit), qubits=[qubit],
+                         schedule=schedule)
 
             # negative pulse
             drag_pulse2 = pulse_lib.drag(duration=pulse_width,
@@ -186,9 +192,9 @@ def drag_schedules(beta_list, qubits, pulse_amp, pulse_width,
 
             schedule2 += drag_pulse2(drives[qubit])
 
-            # append this schedule to the cmd_def
-            cmd_def.add('drag2_%d_%d' % (circ_index, qubit), qubits=[qubit],
-                        schedule=schedule2)
+            # append this schedule to the inst_map
+            inst_map.add('drag2_%d_%d' % (circ_index, qubit), qubits=[qubit],
+                         schedule=schedule2)
 
             circ.append(drag_gate, [qr[qubit]])
             # circ.u1(np.pi, [qr[qubit]])
@@ -200,7 +206,7 @@ def drag_schedules(beta_list, qubits, pulse_amp, pulse_width,
         circuits.append(circ)
 
         # schedule
-        schedule_config = ScheduleConfig(cmd_def, meas_map)
+        schedule_config = ScheduleConfig(inst_map, meas_map)
         drag_sched = [schedule_circuit(qcirc,
                                        schedule_config)
                       for qcirc in circuits]

--- a/test/characterization/test_characterization.py
+++ b/test/characterization/test_characterization.py
@@ -47,7 +47,6 @@ from qiskit.ignis.characterization.calibrations import (rabi_schedules,
                                                         drag_schedules,
                                                         update_u_gates)
 
-import qiskit.pulse as pulse
 from qiskit.test.mock import FakeOpenPulse2Q
 
 # Fix seed for simulations
@@ -472,9 +471,9 @@ class TestCalibs(unittest.TestCase):
 
         update_u_gates(
             single_q_params,
-           qubits=[0],
-           inst_map=self.inst_map,
-           drives=[self.config.drive(i) for i in range(self.n_qubits)])
+            qubits=[0],
+            inst_map=self.inst_map,
+            drives=[self.config.drive(i) for i in range(self.n_qubits)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

 - Only `PulseChannelSpec` caused breaking changes, but `CmdDef` is also deprecated and would cause issues soon enough, so I fixed both

Update Ignis to migrate outdated Terra code: PulseChannelSpec becomes backend.configuration(), CmdDef becomes backend.defaults().instruction_schedule_map. 

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments


Multiple functions which accept cmd_def as an arg now also accept inst_map as the arg name, and will prioritize inst_map over cmd_def. The secondary cmd_def option could be deprecated and later removed.