### PR TITLE
Bump macos version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 
 install_osx: &stage_osx
   os: osx
-  osx_image: xcode9.2
+  osx_image: xcode9.4
   language: generic
   cache:
     pip: true
@@ -35,14 +35,9 @@ install_osx: &stage_osx
         cd ../../..
         python-build $PYTHON_VERSION ~/python-interpreters/$PYTHON_VERSION
       fi
+      sudo pip2 install -U virtualenv pip setuptools
       virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
       source venv/bin/activate
-    fi
-
-before_script:
-   - |
-    if [ ! "$(ls -A .stestr)" ]; then
-        rm -r .stestr
     fi
 
 stages:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently we run macOS CI on macOS 10.12 which was released ~4 yrs ago
and end of life and no longer supported by Apple. Terra added a new
binary requirement retworkx which builds it's wheels against macOS
10.13. This means that pip can't find the wheels for macOS in CI
because 10.13 is too new. This commit bumps the macOS/xcode version
we use in the travis jobs to one slightly newer using macOS 10.13
(which is currently the default travis env). This should unblock CI
because we don't need to install retworkx from source.

### Details and comments