### PR TITLE
Fix iden to remove deprecation warnings

### DIFF
--- a/qiskit/ignis/characterization/characterization_utils.py
+++ b/qiskit/ignis/characterization/characterization_utils.py
@@ -34,7 +34,12 @@ def pad_id_gates(circuit, qr, qubit, num_of_id_gates):
 
     for _ in range(num_of_id_gates):
         circuit.barrier(qr[qubit])
-        circuit.iden(qr[qubit])
+        # Maintain compatibility with 0.12 stable terra
+        # the case of .iden should be removed once terra 0.13 is stable
+        if hasattr(circuit, 'i'):
+            circuit.i(qr[qubit])
+        else:
+            circuit.iden(qr[qubit])
 
     circuit.barrier(qr[qubit])
     return circuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Circuit `iden` method has been deprecated in qiskit-terra/master. This fix uses the new circuit method `i` if it is available, but maintains backwards compatibility for current qiskit-terra/stable if it is not.

### Details and comments


