### PR TITLE
Move MacOS Python 3.8 travis job to cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ matrix:
     - stage: all_python
       <<: *stage_osx
       name: "Python 3.8 Tests on OSX"
+      if: type = cron
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.8.1

--- a/test/rb/test_rb.py
+++ b/test/rb/test_rb.py
@@ -544,7 +544,7 @@ class TestRB(unittest.TestCase):
                     npurity, 3 ** len(rb_opts['rb_pattern'][0]),
                     'Error: npurity does not equal to 3^n')
 
-        except OSError:
+        except (OSError, EOFError):
             skip_msg = ('Skipping tests for %s qubits because '
                         'tables are missing' % str(nq))
             raise unittest.SkipTest(skip_msg)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Makes Mac 3.8 only run on cron job since it is taking up to 50mins to run instead of 5-10 mins for all other python versions and OSes.

* Adds exception case for `EOFError` which is not caught be `OSError` for `test_rb` test that is occasionally failing due to not finding clifford table pickled files.

### Details and comments


