### PR TITLE
Exclude new release of scs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ language: python
 install: pip install -U tox pip virtualenv setuptools six
 script:
   - tox --notest
-  - .tox/$TOXENV/bin/pip install --no-cache-dir --ignore-installed scs!=2.1.2
+  - .tox/$TOXENV/bin/pip install --no-cache-dir --ignore-installed 'scs<2.1.2'
   - tox
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ language: python
 install: pip install -U tox pip virtualenv setuptools six
 script:
   - tox --notest
-  - .tox/$TOXENV/bin/pip install --no-cache-dir --ignore-installed scs
+  - .tox/$TOXENV/bin/pip install --no-cache-dir --ignore-installed scs!=2.1.2
   - tox
 
 notifications:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

scs which is used as an indirect dependency of cvxpy to run our tests
pushed a new release today that is causing issue with the osx ci jobs.
This commit excludes this new release to revert to a known working
version and unblock CI.

### Details and comments


