### PR TITLE
Install git from master on pylint and docs jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ commands =
 [testenv:lint]
 basepython = python3
 deps =
+  git+https://github.com/Qiskit/qiskit-terra.git
   pycodestyle
   pylint
   setuptools>=40.1.0
@@ -31,6 +32,7 @@ commands =
 [testenv:docs]
 basepython = python3
 deps =
+    git+https://github.com/Qiskit/qiskit-terra.git
     -r{toxinidir}/requirements-dev.txt
     qiskit-ibmq-provider
 commands =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the tox job definitions for the lint checks and docs
builds to include terra from master. Right now these jobs were depending
on the requirements list for ignis to install terra as a dependency.
Which meant that we only ever terra installed from pypi. This was
blocking changes that depend on new features or other api changes from
terra. Ensuring that we install terra from master for all jobs ensures
that the test envs are all consistent.

### Details and comments


