### PR TITLE
Avoid implict marshmallow usage

### DIFF
--- a/qiskit/ignis/measurement/discriminator/filters.py
+++ b/qiskit/ignis/measurement/discriminator/filters.py
@@ -26,7 +26,6 @@ from qiskit.ignis.measurement.discriminator.discriminators import \
     BaseDiscriminationFitter
 from qiskit.result.result import Result
 from qiskit.result.models import ExperimentResultData
-from qiskit.validation.base import Obj
 
 
 class DiscriminationFilter:
@@ -88,7 +87,7 @@ class DiscriminationFilter:
         start = 0
         for idx, n_shots in enumerate(shots_per_experiment_result):
             memory = y_data[start:(start+n_shots)]
-            counts = Obj.from_dict(self.count(memory))
+            counts = self.count(memory)
             new_results.results[idx].data = ExperimentResultData(counts=counts,
                                                                  memory=memory)
             start += n_shots

--- a/qiskit/ignis/mitigation/measurement/filters.py
+++ b/qiskit/ignis/mitigation/measurement/filters.py
@@ -24,7 +24,6 @@ from scipy.optimize import minimize
 import scipy.linalg as la
 import numpy as np
 import qiskit
-from qiskit.validation.base import Obj
 from qiskit import QiskitError
 from qiskit.tools import parallel_map
 from ...verification.tomography import count_keys
@@ -146,8 +145,7 @@ class MeasurementFilter():
                 task_args=(raw_data, method))
 
             for resultidx, new_counts in new_counts_list:
-                new_result.results[resultidx].data.counts = \
-                    Obj(**new_counts)
+                new_result.results[resultidx].data.counts = new_counts
 
             return new_result
 
@@ -326,8 +324,7 @@ class TensoredFilter():
                 task_args=(raw_data, method))
 
             for resultidx, new_counts in new_counts_list:
-                new_result.results[resultidx].data.counts = \
-                    Obj(**new_counts)
+                new_result.results[resultidx].data.counts = new_counts
 
             return new_result
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The Results class in terra is no longer constructed via marshmallow
since Qiskit/qiskit-terra#4030 merged. When updating the counts in a result object the
dictionary can now be set directly instead of needlessly wrapping it in
a marshmallow container for a dictionary. Besides fixing compatibility
with terra 0.15.0/master it also will improve performance because there
is no extra overhead from marshmallow constructing and running
validation prior to updating the attribute.


### Details and comments