### PR TITLE
Add README as pypi long description

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include qiskit/ignis/VERSION.txt
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,18 @@ version_path = os.path.abspath(
 with open(version_path, 'r') as fd:
     version = fd.read().rstrip()
 
+README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                           'README.md')
+with open(README_PATH) as readme_file:
+    README = readme_file.read()
+
+
 setuptools.setup(
     name="qiskit-ignis",
     version=version,
     description="Qiskit tools for quantum information science",
+    long_description=README,
+    long_description_content_type='text/markdown',
     url="https://github.com/Qiskit/qiskit-ignis",
     author="Qiskit Development Team",
     author_email="qiskit@qiskit.org",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The long description field was missing from the pypi package this leads
to the package page on pypi showing "The author of this package has not
provided a project description" instead of any details about the
package. This commit updates the package metadata to use the README as
the long description so that a rendered version will be shown on the
pypi page.

### Details and comments