### PR TITLE
Raising error when incompatible inputs are passed to mitigation

### DIFF
--- a/qiskit/ignis/mitigation/measurement/filters.py
+++ b/qiskit/ignis/mitigation/measurement/filters.py
@@ -108,6 +108,11 @@ class MeasurementFilter():
         # check forms of raw_data
         if isinstance(raw_data, dict):
             # counts dictionary
+            for data_label in raw_data.keys():
+                if data_label not in self._state_labels:
+                    raise QiskitError("Unexpected state label '" + data_label +
+                                      "', verify the fitter's state labels "
+                                      "correpsond to the input data")
             data_format = 0
             # convert to form2
             raw_data2 = [np.zeros(len(self._state_labels), dtype=float)]

--- a/releasenotes/notes/mitigtion-label-error-137dd0acfdcfc5f6.yaml
+++ b/releasenotes/notes/mitigtion-label-error-137dd0acfdcfc5f6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Raises `QiskitError` when using incorrect labels in measurement mitigation.


### PR DESCRIPTION
This PR addresses #308 which arose from wrong initialization of the calibration circuits which did not raise a meaningful error. There may be additional changes that can be done (e.g. passing the circuit to the calibration circuits method and letting it decide what the quantum register is by itself).

Closes #308 