### PR TITLE
Tomography multiple jobs fix

### DIFF
--- a/qiskit/ignis/verification/tomography/fitters/base_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/base_fitter.py
@@ -40,7 +40,7 @@ class TomographyFitter:
     """Base maximum-likelihood estimate tomography fitter class"""
 
     def __init__(self,
-                 result: Result,
+                 result: Union[Result, List[Result]],
                  circuits: Union[List[QuantumCircuit], List[str]],
                  meas_basis: Union[TomographyBasis, str] = 'Pauli',
                  prep_basis: Union[TomographyBasis, str] = 'Pauli'):
@@ -67,6 +67,8 @@ class TomographyFitter:
 
         # Add initial data
         self._data = {}
+        if isinstance(result, Result):
+            result = [result]  # unify results handling
         self.add_data(result, circuits)
 
     def set_measure_basis(self, basis: Union[TomographyBasis, str]):
@@ -223,14 +225,20 @@ class TomographyFitter:
         """
         return self._data
 
-    def add_data(self, result, circuits):
+    def add_data(self,
+                 results: List[Result],
+                 circuits: List[Union[QuantumCircuit, str]]
+                 ):
         """Add tomography data from a Qiskit Result object.
 
         Args:
-            result (Result): a Qiskit Result object obtained from executing
-                tomography circuits.
-            circuits (list): a list of circuits or circuit names to extract
+            results: The results obtained from executing tomography circuits.
+            circuits: circuits or circuit names to extract
                 count information from the result object.
+
+        Raises:
+            QiskitError: In case some of the tomography data is not found
+                in the results
         """
         if len(circuits[0].cregs) == 1:
             marginalize = False
@@ -239,7 +247,14 @@ class TomographyFitter:
 
         # Process measurement counts into probabilities
         for circ in circuits:
-            counts = result.get_counts(circ)
+            counts = None
+            for result in results:
+                try:
+                    counts = result.get_counts(circ)
+                except QiskitError:
+                    pass
+            if counts is None:
+                raise QiskitError("Result for {} not found".format(circ.name))
             if isinstance(circ, str):
                 tup = literal_eval(circ)
             elif isinstance(circ, QuantumCircuit):

--- a/releasenotes/notes/tomography-fitters-list-input-2bfb567058316eed.yaml
+++ b/releasenotes/notes/tomography-fitters-list-input-2bfb567058316eed.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Tomography fitters can now also get list of `Result` objects instead of a single `Result`
+    as requested in `issue #320 <https://github.com/Qiskit/qiskit-ignis/issues/320/>`_.

--- a/test/tomography/test_state_tomography.py
+++ b/test/tomography/test_state_tomography.py
@@ -139,6 +139,28 @@ class TestStateTomography(unittest.TestCase):
         F_bell_mle = state_fidelity(psi, rho_mle, validate=False)
         self.assertAlmostEqual(F_bell_mle, 1, places=1)
 
+    def test_split_job(self):
+        q3 = QuantumRegister(3)
+        bell = QuantumCircuit(q3)
+        bell.h(q3[0])
+        bell.cx(q3[0], q3[1])
+        bell.cx(q3[1], q3[2])
+
+        psi = Statevector.from_instruction(bell)
+        qst = tomo.state_tomography_circuits(bell, q3)
+        qst1 = qst[:len(qst) // 2]
+        qst2 = qst[len(qst) // 2:]
+
+        backend = Aer.get_backend('qasm_simulator')
+        job1 = qiskit.execute(qst1, backend, shots=5000)
+        job2 = qiskit.execute(qst2, backend, shots=5000)
+
+        tomo_fit = tomo.StateTomographyFitter([job1.result(), job2.result()], qst)
+
+        rho_mle = tomo_fit.fit(method='lstsq')
+        F_bell_mle = state_fidelity(psi, rho_mle, validate=False)
+        self.assertAlmostEqual(F_bell_mle, 1, places=1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The goal of this PR is to add the feature request of #320 to allow tomography to accept multiple results and handle them automatically.