### PR TITLE
Fix issues with CVXPY default solvers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ language: python
 install: pip install -U tox pip virtualenv setuptools six
 script:
   - tox --notest
-  - .tox/$TOXENV/bin/pip install --no-cache-dir --ignore-installed 'scs<2.1.2'
+  - .tox/$TOXENV/bin/pip install --no-cache-dir cvxopt
   - tox
 
 notifications:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,9 @@ jobs:
           displayName: Create Anaconda environment
         - script: |
             call activate qiskit-ignis
+            conda config --add channels conda-forge
+            conda install cvxopt
             python -m pip install -c constraints.txt --upgrade pip virtualenv setuptools
-            pip install -c constraints.txt -U tox cvxopt
+            pip install -c constraints.txt -U tox
             tox --sitepackages -e%TOXENV%
           displayName: 'Install dependencies and run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,9 +64,6 @@ jobs:
         - script: conda create --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION%
           displayName: Create Anaconda environment
         - script: |
-            call activate qiskit-ginis
-            pip install cvxopt
-        - script: |
             call activate qiskit-ignis
             python -m pip install -c constraints.txt --upgrade pip virtualenv setuptools
             pip install -c constraints.txt -U tox cxvopt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,6 @@ jobs:
         - script: |
             call activate qiskit-ignis
             python -m pip install -c constraints.txt --upgrade pip virtualenv setuptools
-            pip install -c constraints.txt -U tox cxvopt
+            pip install -c constraints.txt -U tox cvxopt
             tox --sitepackages -e%TOXENV%
           displayName: 'Install dependencies and run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,6 @@ jobs:
           Python35:
             python.version: '3.5'
             TOXENV: py35
-            OPENBLAS: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
           Python36:
             python.version: '3.6'
             TOXENV: py36
@@ -65,46 +64,11 @@ jobs:
         - script: conda create --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION%
           displayName: Create Anaconda environment
         - script: |
-            call activate qiskit-ignis
-            conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% scs
-          displayName: Install Anaconda packages
-          condition: ne(variables['python.version'], '3.5')
-        - script: |
-            call activate qiskit-ignis
-            conda install --yes --quiet --name qiskit-ignis --channel conda-forge python=%PYTHON_VERSION% osqp
-          displayName: Install Anaconda packages
-          condition: eq(variables['python.version'], '3.8')
-        - powershell: (new-object System.Net.WebClient).DownloadFile($env:OPENBLAS, 'c:\openblas.zip')
-          condition: eq(variables['python.version'], '3.5')
-          displayName: 'Download openblas'
-        - powershell: Expand-Archive c:\openblas.zip c:\openblas
-          condition: eq(variables['python.version'], '3.5')
-          displayName: 'Unzip openblas'
-        - script: |
-            call activate qiskit-ignis
-            conda install --yes --quiet --update-all --name qiskit-ignis python=%PYTHON_VERSION% numpy scipy
-          displayName: Install Anaconda packages
-          condition: eq(variables['python.version'], '3.5')
-        - script: |
-            call activate qiskit-ignis
-            set PATH=%PATH%;%BINPATH%;C:\openblas\%64%\bin;
-            echo %PATH%
-            dir C:\openblas\%ARCH%\bin
-            make.exe CC="gcc.exe -m64" USE_LAPACK=1 BLASLDFLAGS="-LC:\openblas\64\bin -lopenblas_5f998ef_gcc7_1_0"
-            make.exe install
-            git clone --recursive https://github.com/bodono/scs-python.git
-            cd scs-python
-            python setup.py install --scs 'CC="gcc.exe -m64" USE_LAPACK=1 BLASLDFLAGS="-LC:\openblas\64\bin -lopenblas_5f998ef_gcc7_1_0"'
-            cd ..
-          condition: eq(variables['python.version'], '3.5')
-          displayName: 'Install scs from source for python 3.5'
-        - script: |
-            call activate qiskit-ignis
-            conda install --yes --quiet --name qiskit-ignis python=%PYTHON_VERSION% mkl
-          displayName: 'Install MKL'
+            call activate qiskit-ginis
+            pip install cvxopt
         - script: |
             call activate qiskit-ignis
             python -m pip install -c constraints.txt --upgrade pip virtualenv setuptools
-            pip install -c constraints.txt -U tox
+            pip install -c constraints.txt -U tox cxvopt
             tox --sitepackages -e%TOXENV%
           displayName: 'Install dependencies and run tests'

--- a/qiskit/ignis/verification/tomography/fitters/base_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/base_fitter.py
@@ -495,6 +495,7 @@ class TomographyFitter:
         """Check if CVXPY solver is available"""
         if cls._HAS_SDP_SOLVER is None:
             if _HAS_CVX:
+                # pylint:disable=import-error
                 import cvxpy
                 solvers = cvxpy.installed_solvers()
                 if 'CVXOPT' in solvers:

--- a/qiskit/ignis/verification/tomography/fitters/base_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/base_fitter.py
@@ -29,7 +29,7 @@ from qiskit import QuantumCircuit
 from qiskit.result import Result
 from ..basis import TomographyBasis, default_basis
 from ..data import marginal_counts, combine_counts, count_keys
-from .cvx_fit import cvxpy, cvx_fit
+from .cvx_fit import cvx_fit, _HAS_CVX, _DEFAULT_SOLVER
 from .lstsq_fit import lstsq_fit
 
 # Create logger
@@ -195,10 +195,10 @@ class TomographyFitter:
                                                         beta)
         # Choose automatic method
         if method == 'auto':
-            if cvxpy is None:
-                method = 'lstsq'
-            else:
+            if _HAS_CVX and _DEFAULT_SOLVER:
                 method = 'cvx'
+            else:
+                method = 'lstsq'
         if method == 'lstsq':
             return lstsq_fit(data, basis_matrix,
                              weights=weights,

--- a/qiskit/ignis/verification/tomography/fitters/base_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/base_fitter.py
@@ -29,8 +29,8 @@ from qiskit import QuantumCircuit
 from qiskit.result import Result
 from ..basis import TomographyBasis, default_basis
 from ..data import marginal_counts, combine_counts, count_keys
-from .cvx_fit import cvx_fit, _HAS_CVX, _DEFAULT_SOLVER
 from .lstsq_fit import lstsq_fit
+from .cvx_fit import cvx_fit, _HAS_CVX
 
 # Create logger
 logger = logging.getLogger(__name__)
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 class TomographyFitter:
     """Base maximum-likelihood estimate tomography fitter class"""
+
+    _HAS_SDP_SOLVER = None
 
     def __init__(self,
                  result: Result,
@@ -195,7 +197,8 @@ class TomographyFitter:
                                                         beta)
         # Choose automatic method
         if method == 'auto':
-            if _HAS_CVX and _DEFAULT_SOLVER:
+            self._check_for_sdp_solver()
+            if self._HAS_SDP_SOLVER:
                 method = 'cvx'
             else:
                 method = 'lstsq'
@@ -486,3 +489,27 @@ class TomographyFitter:
                 op = np.kron(op, meas_matrix_fn(m, outcome))
             meas_ops.append(op)
         return meas_ops
+
+    @classmethod
+    def _check_for_sdp_solver(cls):
+        """Check if CVXPY solver is available"""
+        if cls._HAS_SDP_SOLVER is None:
+            if _HAS_CVX:
+                import cvxpy
+                solvers = cvxpy.installed_solvers()
+                if 'CVXOPT' in solvers:
+                    cls._HAS_SDP_SOLVER = True
+                    return
+                if 'SCS' in solvers:
+                    # Try example problem to see if built with BLAS
+                    # SCS solver cannot solver larger than 2x2 matrix
+                    # problems without BLAS
+                    try:
+                        var = cvxpy.Variable((4, 4), PSD=True)
+                        obj = cvxpy.Minimize(cvxpy.norm(var))
+                        cvxpy.Problem(obj).solve(solver='SCS')
+                        cls._HAS_SDP_SOLVER = True
+                        return
+                    except cvxpy.error.SolverError:
+                        pass
+            cls._HAS_SDP_SOLVER = False

--- a/qiskit/ignis/verification/tomography/fitters/cvx_fit.py
+++ b/qiskit/ignis/verification/tomography/fitters/cvx_fit.py
@@ -29,26 +29,6 @@ except ImportError:
     _HAS_CVX = False
 
 
-def _default_sdp_solver():
-    solvers = cvxpy.installed_solvers()
-    if 'CVXOPT' in solvers:
-        return 'CVXOPT'
-    if 'SCS' in solvers:
-        # Try example problem to see if BLAS is installed
-        try:
-            var = cvxpy.Variable((4, 4), PSD=True)
-            obj = cvxpy.Minimize(cvxpy.norm(var))
-            cvxpy.Problem(obj).solve(solver='SCS')
-            return 'SCS'
-        except cvxpy.error.SolverError:
-            return None
-    return None
-
-
-# Check if a suitable default solver is available
-_DEFAULT_SOLVER = _default_sdp_solver()
-
-
 def cvx_fit(data: np.array,
             basis_matrix: np.array,
             weights: Optional[np.array] = None,
@@ -215,7 +195,8 @@ def cvx_fit(data: np.array,
     max_iters = kwargs.get('max_iters', 20000)
     # Set default solver if none is specified
     if 'solver' not in kwargs:
-        kwargs['solver'] = _DEFAULT_SOLVER
+        if 'CVXOPT' in cvxpy.installed_solvers():
+            kwargs['solver'] = 'CVXOPT'
 
     problem_solved = False
     while not problem_solved:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Fixes deprecated multiplication operators 
* Adds a check to set default SDP solver based on installed solvers in cvxpy, preferring 'CVXOP' if installed, then 'SCS'.
* Changes auto method of tomography fitter to only use 'cvx' when a default solver is sound.

### Details and comments

When checking if 'SCS' is installed, this runs a short optimization problem to see if SCS is built with BLAS support, since it cannot solve problems bigger than 2x2 matrices without it.

