### PR TITLE
Fix breaking attribute name change

### DIFF
--- a/qiskit/ignis/verification/accreditation/fitters.py
+++ b/qiskit/ignis/verification/accreditation/fitters.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=invalid-name
+
 
 """
 Class for accreditation protocol
@@ -38,7 +40,7 @@ class AccreditationFitter:
 
     bound = 1
     confidence = 1
-    n_acc = 0
+    N_acc = 0
     num_runs = 0
     flag = 'accepted'
     outputs = []
@@ -90,7 +92,7 @@ class AccreditationFitter:
             else:
                 output_target = count
         if self.flag == 'accepted':
-            self.n_acc += 1
+            self.N_acc += 1
             self.outputs.append(output_target)
 
     def bound_variation_distance(self, theta):
@@ -101,12 +103,12 @@ class AccreditationFitter:
         Args:
             theta (float): number between 0 and 1
         """
-        if self.n_acc == 0:
+        if self.N_acc == 0:
             QiskitError("ERROR: Variation distance requires"
                         "at least one accepted run")
-        if self.n_acc/self.num_runs > theta:
+        if self.N_acc/self.num_runs > theta:
             self.bound = self.g_num*1.7/(self.num_traps+1)
-            self.bound = self.bound/(self.n_acc/self.num_runs-theta)
+            self.bound = self.bound/(self.N_acc/self.num_runs-theta)
             self.bound = self.bound+1-self.g_num
             self.confidence = 1-2*np.exp(-2*theta*self.num_runs*self.num_runs)
         if self.bound > 1:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #370 the name of the N_acc attribute was renamed to n_acc to adapt to
the pylint naming rules. However, this wwas neglecting that this
attribute was part of the API for the class, and people were using it as
N_acc. This commit reverts the breaking change and changes the name back
to N_acc.

### Details and comments

