### PR TITLE
[Stable] Fix fitter selection logic in process tomography (#431)

### DIFF
--- a/qiskit/ignis/verification/tomography/fitters/process_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/process_fitter.py
@@ -21,7 +21,7 @@ import numpy as np
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Choi
 from .base_fitter import TomographyFitter
-from .cvx_fit import cvxpy, cvx_fit
+from .cvx_fit import cvx_fit
 from .lstsq_fit import lstsq_fit
 
 
@@ -137,10 +137,11 @@ class ProcessTomographyFitter(TomographyFitter):
                              "to a process matrix.")
         # Choose automatic method
         if method == 'auto':
-            if cvxpy is None:
-                method = 'lstsq'
-            else:
+            self._check_for_sdp_solver()
+            if self._HAS_SDP_SOLVER:
                 method = 'cvx'
+            else:
+                method = 'lstsq'
         if method == 'lstsq':
             return Choi(lstsq_fit(data, basis_matrix, weights=weights,
                                   trace=dim, **kwargs))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-cvxpy>=1.0.15
 pylint==2.4.4
 pycodestyle
 qiskit-aer>=0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ setenv =
 deps = numpy>=1.13
        Cython>=0.27.1
        setuptools>=40.1.0
+       cvxpy>=1.0.15
 commands =
     pip install -U -c constraints.txt qiskit-terra
     pip install -U -c constraints.txt -r{toxinidir}/requirements-dev.txt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the process tomography module. When cvxpy
was not installed the module would fail to import. That's because the
selection logic was reworked in #422 but never updated in process
tomography to reflect that change. Since no CI job runs without cvxpy
installed we never caught this edge case. This commit fixes the
underlying issue to rework the process tomography fitter selection logic
to mirror the changes to state tomography in #422 and then also try and
add ci coverage it removes cvxpy from the docs tox job. With warnings
set to fatal this should ensure we are always able to import everything
and build the docs if cvxpy is not installed.

### Details and comments
Backported from #431 
Fixes #429

(cherry picked from commit 01e907049cf6fdd8323ff1a524a51bbee20407ae)
