### PR TITLE
fixed partial trace constraint in cvx fitting routine

### DIFF
--- a/qiskit/ignis/verification/tomography/fitters/cvx_fit.py
+++ b/qiskit/ignis/verification/tomography/fitters/cvx_fit.py
@@ -155,6 +155,7 @@ def cvx_fit(data: np.array,
         sdim = int(np.sqrt(dim))
         ptr = partial_trace_super(sdim, sdim)
         cons.append(ptr @ cvxpy.vec(rho_r) == np.identity(sdim).ravel())
+        cons.append(ptr @ cvxpy.vec(rho_i) == np.zeros(sdim*sdim))
 
     # Rescale input data and matrix by weights if they are provided
     if weights is not None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #437

### Details and comments

When doing process tomography with the `cvx` method, one can include a constraint s.t. the resulting quantum channel will be trace preserving. Mathematically this constraint corresponds to the partial trace of the Choi matrix being the identity.

In the code, only the real part of the partial trace is compared with the identity, but not the imaginary part.

