### PR TITLE
[Stable] Add scikit-learn dependency and add CI job without optional dependencies (#436)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,12 @@ matrix:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.8.1
         - TOXENV=py38
+    - python: "3.8"
+      name: "Python 3.8 tests without optional dependencies"
+      stage: all_python
+      env: TOXENV=no-opt
+      stage: all_python
+      script: tox
     - if: tag IS present
       python: "3.6"
       env:

--- a/releasenotes/notes/missing-dependency-e7c99c7751bcd162.yaml
+++ b/releasenotes/notes/missing-dependency-e7c99c7751bcd162.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    A new requirement `scikit-learn <https://scikit-learn.org/stable/>`__ has
+    been added to the requirements list. This dependency was added in the 0.3.0
+    release but wasn't properly exposed as a dependency in that release. This
+    would lead to an ``ImportError`` if the
+    :mod:`qiskit.ignis.measurement.discriminator.iq_discriminators` module was
+    imported. This is now correctly listed as a dependency so that
+    ``scikit-learn`` will be installed with qiskit-ignis.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ requirements = [
     "qiskit-terra>=0.13.0",
     "scipy>=0.19,!=0.19.1",
     "setuptools>=40.1.0",
+    "scikit-learn>=0.17",
 ]
 
 

--- a/test/tomography/test_process_tomography.py
+++ b/test/tomography/test_process_tomography.py
@@ -24,20 +24,23 @@ from qiskit.quantum_info import state_fidelity
 from qiskit.quantum_info import Choi
 
 import qiskit.ignis.verification.tomography as tomo
+from qiskit.ignis.verification.tomography.fitters import cvx_fit
 
 
-def run_circuit_and_tomography(circuit, qubits):
+def run_circuit_and_tomography(circuit, qubits, method):
     choi_ideal = Choi(circuit).data
     qst = tomo.process_tomography_circuits(circuit, qubits)
     job = qiskit.execute(qst, Aer.get_backend('qasm_simulator'),
                          shots=5000)
     tomo_fit = tomo.ProcessTomographyFitter(job.result(), qst)
-    choi_cvx = tomo_fit.fit(method='cvx').data
-    choi_mle = tomo_fit.fit(method='lstsq').data
-    return (choi_cvx, choi_mle, choi_ideal)
+    choi = tomo_fit.fit(method=method).data
+    return (choi, choi_ideal)
 
 
 class TestProcessTomography(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.method = 'lstsq'
 
     def test_bell_2_qubits(self):
         q2 = QuantumRegister(2)
@@ -45,11 +48,16 @@ class TestProcessTomography(unittest.TestCase):
         bell.h(q2[0])
         bell.cx(q2[0], q2[1])
 
-        choi_cvx, choi_mle, choi_ideal = run_circuit_and_tomography(bell, q2)
-        F_bell_cvx = state_fidelity(choi_ideal/4, choi_cvx/4, validate=False)
-        self.assertAlmostEqual(F_bell_cvx, 1, places=1)
-        F_bell_mle = state_fidelity(choi_ideal/4, choi_mle/4, validate=False)
-        self.assertAlmostEqual(F_bell_mle, 1, places=1)
+        choi, choi_ideal = run_circuit_and_tomography(bell, q2, self.method)
+        F_bell = state_fidelity(choi_ideal/4, choi/4, validate=False)
+        self.assertAlmostEqual(F_bell, 1, places=1)
+
+
+@unittest.skipUnless(cvx_fit._HAS_CVX, 'cvxpy is required for this test')
+class TestProcessTomographyCVX(TestProcessTomography):
+    def setUp(self):
+        super().setUp()
+        self.method = 'cvx'
 
 
 if __name__ == '__main__':

--- a/test/tomography/test_state_tomography.py
+++ b/test/tomography/test_state_tomography.py
@@ -26,19 +26,18 @@ import qiskit.ignis.verification.tomography as tomo
 import qiskit.ignis.verification.tomography.fitters.cvx_fit as cvx_fit
 
 
-def run_circuit_and_tomography(circuit, qubits):
+def run_circuit_and_tomography(circuit, qubits, method='lstsq'):
     psi = Statevector.from_instruction(circuit)
     qst = tomo.state_tomography_circuits(circuit, qubits)
     job = qiskit.execute(qst, Aer.get_backend('qasm_simulator'),
                          shots=5000)
     tomo_fit = tomo.StateTomographyFitter(job.result(), qst)
-    rho_cvx = tomo_fit.fit(method='cvx')
-    rho_mle = tomo_fit.fit(method='lstsq')
-    return (rho_cvx, rho_mle, psi)
+    rho = tomo_fit.fit(method=method)
+    return (rho, psi)
 
 
+@unittest.skipUnless(cvx_fit._HAS_CVX, 'cvxpy is required to run this test')
 class TestFitter(unittest.TestCase):
-
     def test_trace_constraint(self):
         p = numpy.array([1/2, 1/2, 1/2, 1/2, 1/2, 1/2])
 
@@ -58,6 +57,9 @@ class TestFitter(unittest.TestCase):
 
 
 class TestStateTomography(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.method = 'lstsq'
 
     def test_bell_2_qubits(self):
         q2 = QuantumRegister(2)
@@ -65,22 +67,18 @@ class TestStateTomography(unittest.TestCase):
         bell.h(q2[0])
         bell.cx(q2[0], q2[1])
 
-        rho_cvx, rho_mle, psi = run_circuit_and_tomography(bell, q2)
-        F_bell_cvx = state_fidelity(psi, rho_cvx, validate=False)
-        self.assertAlmostEqual(F_bell_cvx, 1, places=1)
-        F_bell_mle = state_fidelity(psi, rho_mle, validate=False)
-        self.assertAlmostEqual(F_bell_mle, 1, places=1)
+        rho, psi = run_circuit_and_tomography(bell, q2, self.method)
+        F_bell = state_fidelity(psi, rho, validate=False)
+        self.assertAlmostEqual(F_bell, 1, places=1)
 
     def test_bell_2_qubits_no_register(self):
         bell = QuantumCircuit(2)
         bell.h(0)
         bell.cx(0, 1)
 
-        rho_cvx, rho_mle, psi = run_circuit_and_tomography(bell, (0, 1))
-        F_bell_cvx = state_fidelity(psi, rho_cvx, validate=False)
-        self.assertAlmostEqual(F_bell_cvx, 1, places=1)
-        F_bell_mle = state_fidelity(psi, rho_mle, validate=False)
-        self.assertAlmostEqual(F_bell_mle, 1, places=1)
+        rho, psi = run_circuit_and_tomography(bell, (0, 1), self.method)
+        F_bell = state_fidelity(psi, rho, validate=False)
+        self.assertAlmostEqual(F_bell, 1, places=1)
 
     def test_different_qubit_sets(self):
         circuit = QuantumCircuit(5)
@@ -92,12 +90,10 @@ class TestStateTomography(unittest.TestCase):
         circuit.cx(1, 3)
 
         for qubit_pair in [(0, 1), (2, 3), (1, 4), (0, 3)]:
-            rho_cvx, rho_mle, psi = run_circuit_and_tomography(circuit, qubit_pair)
+            rho, psi = run_circuit_and_tomography(circuit, qubit_pair, self.method)
             psi = partial_trace(psi, [x for x in range(5) if x not in qubit_pair])
-            F_cvx = state_fidelity(psi, rho_cvx, validate=False)
-            self.assertAlmostEqual(F_cvx, 1, places=1)
-            F_mle = state_fidelity(psi, rho_mle, validate=False)
-            self.assertAlmostEqual(F_mle, 1, places=1)
+            F = state_fidelity(psi, rho, validate=False)
+            self.assertAlmostEqual(F, 1, places=1)
 
     def test_bell_3_qubits(self):
         q3 = QuantumRegister(3)
@@ -106,22 +102,18 @@ class TestStateTomography(unittest.TestCase):
         bell.cx(q3[0], q3[1])
         bell.cx(q3[1], q3[2])
 
-        rho_cvx, rho_mle, psi = run_circuit_and_tomography(bell, q3)
-        F_bell_cvx = state_fidelity(psi, rho_cvx, validate=False)
-        self.assertAlmostEqual(F_bell_cvx, 1, places=1)
-        F_bell_mle = state_fidelity(psi, rho_mle, validate=False)
-        self.assertAlmostEqual(F_bell_mle, 1, places=1)
+        rho, psi = run_circuit_and_tomography(bell, q3, self.method)
+        F_bell = state_fidelity(psi, rho, validate=False)
+        self.assertAlmostEqual(F_bell, 1, places=1)
 
     def test_complex_1_qubit_circuit(self):
         q = QuantumRegister(1)
         circ = QuantumCircuit(q)
         circ.u3(1, 1, 1, q[0])
 
-        rho_cvx, rho_mle, psi = run_circuit_and_tomography(circ, q)
-        F_bell_cvx = state_fidelity(psi, rho_cvx, validate=False)
-        self.assertAlmostEqual(F_bell_cvx, 1, places=1)
-        F_bell_mle = state_fidelity(psi, rho_mle, validate=False)
-        self.assertAlmostEqual(F_bell_mle, 1, places=1)
+        rho, psi = run_circuit_and_tomography(circ, q, self.method)
+        F_bell = state_fidelity(psi, rho, validate=False)
+        self.assertAlmostEqual(F_bell, 1, places=1)
 
     def test_complex_3_qubit_circuit(self):
         def rand_angles():
@@ -133,11 +125,16 @@ class TestStateTomography(unittest.TestCase):
         for j in range(3):
             circ.u3(*rand_angles(), q[j])
 
-        rho_cvx, rho_mle, psi = run_circuit_and_tomography(circ, q)
-        F_bell_cvx = state_fidelity(psi, rho_cvx, validate=False)
-        self.assertAlmostEqual(F_bell_cvx, 1, places=1)
-        F_bell_mle = state_fidelity(psi, rho_mle, validate=False)
-        self.assertAlmostEqual(F_bell_mle, 1, places=1)
+        rho, psi = run_circuit_and_tomography(circ, q, self.method)
+        F_bell = state_fidelity(psi, rho, validate=False)
+        self.assertAlmostEqual(F_bell, 1, places=1)
+
+
+@unittest.skipUnless(cvx_fit._HAS_CVX, 'cvxpy is required  to run this test')
+class TestStateTomographyCVX(TestStateTomography):
+    def setUp(self):
+        super().setUp()
+        self.method = 'cvx'
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,15 @@ commands =
     pip check
     stestr run {posargs}
 
+[testenv:no-opt]
+deps =
+    qiskit-aer
+    ddt>=1.2.0,!=1.4.0
+    stestr>=2.5.0
+commands =
+    pip check
+    stestr run {posargs}
+
 [testenv:lint]
 basepython = python3
 deps =


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary


* Add scikit-learn dependency and add CI job without optional deps

This commit adds a new ci job for running ignis tests without any
optional dependencies. There are several optional dependencies which do
not not always get installed with ignis. They are needed to enable
optional features but shouldn't be required, we've had a slew of recent
bugs around accidentally requiring these optional dependencies (see
issues #429, #422, and #312). None of these were caught in CI because we
always install all optional dependencies in CI test jobs. By adding a
new job which explicitly installs the bare minimum we're emulating what
a user does when they install just ignis.

As part of this a missing dependency was added to the requirements list.
Ignis has a hard dependency on scikit learn for the measurement
discriminators, but this was never explicitly listed. This was never
caught because the test jobs were always installing it.

* Don't install cvxopt in no-opt job

* Add job name

* Update tox.ini to point to remove master terra for stable branch


### Details and comments

Backported from #436 
(cherry picked from commit f0b68e4ca72eb34fef6224c2fa5ed0f8d7e0ca52)