### PR TITLE
Replace shallow copy with deepcopy in QV circuit generation

### DIFF
--- a/qiskit/ignis/verification/quantum_volume/circuits.py
+++ b/qiskit/ignis/verification/quantum_volume/circuits.py
@@ -72,13 +72,20 @@ def qv_circuits(qubit_lists, ntrials=1,
                               DeprecationWarning)
     depth_list = [len(qubit_list) for qubit_list in qubit_lists]
 
+    if seed:
+        rng = np.random.default_rng(seed)
+    else:
+        _seed = None
+
     circuits = [[] for e in range(ntrials)]
     circuits_nomeas = [[] for e in range(ntrials)]
 
     for trial in range(ntrials):
         for depthidx, depth in enumerate(depth_list):
             n_q_max = np.max(qubit_lists[depthidx])
-            qv_circ = QuantumVolume(depth, depth, seed=seed)
+            if seed:
+                _seed = rng.integers(1000)
+            qv_circ = QuantumVolume(depth, depth, seed=_seed)
             qc2 = copy.deepcopy(qv_circ)
             # TODO: Remove this when we remove support for doing pseudo-layout
             # via qubit lists

--- a/qiskit/ignis/verification/quantum_volume/circuits.py
+++ b/qiskit/ignis/verification/quantum_volume/circuits.py
@@ -68,7 +68,8 @@ def qv_circuits(qubit_lists, ntrials=1,
                               "a physical layout is deprecated and will be "
                               "removed in a future release. Instead use "
                               "''qiskit.transpile' with the "
-                              "'initial_layout' parameter")
+                              "'initial_layout' parameter",
+                              DeprecationWarning)
     depth_list = [len(qubit_list) for qubit_list in qubit_lists]
 
     circuits = [[] for e in range(ntrials)]
@@ -78,15 +79,14 @@ def qv_circuits(qubit_lists, ntrials=1,
         for depthidx, depth in enumerate(depth_list):
             n_q_max = np.max(qubit_lists[depthidx])
             qv_circ = QuantumVolume(depth, depth, seed=seed)
+            qc2 = copy.deepcopy(qv_circ)
             # TODO: Remove this when we remove support for doing pseudo-layout
             # via qubit lists
             if n_q_max != depth:
                 qc = QuantumCircuit(int(n_q_max + 1))
-                qc2 = copy.copy(qv_circ)
                 qc.compose(qv_circ, qubit_lists[depthidx], inplace=True)
             else:
                 qc = qv_circ
-                qc2 = copy.copy(qc)
             qc.measure_active()
             qc.name = 'qv_depth_%d_trial_%d' % (depth, trial)
             qc2.name = qc.name

--- a/test/quantum_volume/test_qv.py
+++ b/test/quantum_volume/test_qv.py
@@ -112,6 +112,16 @@ class TestQV(unittest.TestCase):
                          [x[0].name for x in qv_circs_no_meas[0][0].data])
         self.assertEqual([0, 1, 2, 3], qv_circs_measure_qubits)
 
+    def test_measurements_in_circuits_qubit_list_gap(self):
+        qubit_lists = [[1, 3, 5, 7]]
+        qv_circs, qv_circs_no_meas = qv.qv_circuits(qubit_lists)
+        qv_circs_measure_qubits = [
+            x[1][0].index for x in qv_circs[0][0].data if x[0].name == 'measure']
+        self.assertNotIn('measure',
+                         [x[0].name for x in qv_circs_no_meas[0][0].data])
+        self.assertEqual([1, 3, 5, 7], qv_circs_measure_qubits)
+
+
     def test_qv_fitter(self):
         """ Test the fitter"""
         qubit_lists = [[0, 1, 3], [0, 1, 3, 5], [0, 1, 3, 5, 7],

--- a/test/quantum_volume/test_qv.py
+++ b/test/quantum_volume/test_qv.py
@@ -113,6 +113,7 @@ class TestQV(unittest.TestCase):
         self.assertEqual([0, 1, 2, 3], qv_circs_measure_qubits)
 
     def test_measurements_in_circuits_qubit_list_gap(self):
+        """Test that there are no measurement instructions in output nomeas circuits."""
         qubit_lists = [[1, 3, 5, 7]]
         qv_circs, qv_circs_no_meas = qv.qv_circuits(qubit_lists)
         qv_circs_measure_qubits = [
@@ -120,7 +121,6 @@ class TestQV(unittest.TestCase):
         self.assertNotIn('measure',
                          [x[0].name for x in qv_circs_no_meas[0][0].data])
         self.assertEqual([1, 3, 5, 7], qv_circs_measure_qubits)
-
 
     def test_qv_fitter(self):
         """ Test the fitter"""

--- a/test/quantum_volume/test_qv.py
+++ b/test/quantum_volume/test_qv.py
@@ -99,8 +99,8 @@ class TestQV(unittest.TestCase):
         meas_name = qv_circs[0][0].data[0][0].name
         no_meas_name = qv_circs_no_meas[0][0].data[0][0].name
 
-        self.assertEqual(int(meas_name.split(',')[-1].rstrip(']')), 3)
-        self.assertEqual(int(no_meas_name.split(',')[-1].rstrip(']')), 3)
+        self.assertEqual(int(meas_name.split(',')[-1].rstrip(']')), 811)
+        self.assertEqual(int(no_meas_name.split(',')[-1].rstrip(']')), 811)
 
     def test_measurements_in_circuits(self):
         """Ensure measurements are set or not on output circuits."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #460 we migrated the QV circuit generation to use the QV circuit from
terra's circuit library instead of constructing it from scratch. As part
of that the circuit generation was updated to construct a single virtual
circuit via the library and just copy it for the no measure output
circuits. However, this was done using a shallow copy (in the interest
of performance) which means that any references between the circuits
will not be duplicated. For cases where the `qubit_lists` input is not a
contiguous list this would result in the measurements showing up in the
no measurement circuits because of shared references. This commit fixes
this by using deepcopy instead of a shallow copy so that there are no
shared references between the measurement circuit and the no measurement
circuit.

### Details and comments