### PR TITLE
add seed for measurement calibration tests

### DIFF
--- a/test/measurement_calibration/test_meas.py
+++ b/test/measurement_calibration/test_meas.py
@@ -190,7 +190,8 @@ class TestMeasCal(unittest.TestCase):
         backend = Aer.get_backend('qasm_simulator')
         job = qiskit.execute(meas_calibs, backend=backend,
                              shots=self.shots,
-                             seed_simulator=SEED)
+                             seed_simulator=SEED,
+                             seed_transpiler=SEED)
         cal_results = job.result()
 
         # Make a calibration matrix
@@ -200,7 +201,8 @@ class TestMeasCal(unittest.TestCase):
 
         job = qiskit.execute([ghz], backend=backend,
                              shots=self.shots,
-                             seed_simulator=SEED)
+                             seed_simulator=SEED,
+                             seed_transpiler=SEED)
         results = job.result()
 
         # Predicted equally distributed results
@@ -351,7 +353,8 @@ class TestMeasCal(unittest.TestCase):
         backend = Aer.get_backend('qasm_simulator')
         cal_results = qiskit.execute(meas_calibs, backend=backend,
                                      shots=self.shots,
-                                     seed_simulator=SEED).result()
+                                     seed_simulator=SEED,
+                                     seed_transpiler=SEED).result()
 
         # Make a calibration matrix
         meas_cal = TensoredMeasFitter(cal_results,
@@ -361,7 +364,8 @@ class TestMeasCal(unittest.TestCase):
 
         results = qiskit.execute([ghz], backend=backend,
                                  shots=self.shots,
-                                 seed_simulator=SEED).result()
+                                 seed_simulator=SEED,
+                                 seed_transpiler=SEED).result()
 
         # Predicted equally distributed results
         predicted_results = {'000': 0.5,

--- a/test/measurement_calibration/test_meas.py
+++ b/test/measurement_calibration/test_meas.py
@@ -44,7 +44,7 @@ from qiskit.ignis.mitigation.measurement \
              MeasurementFilter)
 from qiskit.ignis.verification.tomography import count_keys
 
-# fixed seed for tests
+# fixed seed for tests - for both simulator and transpiler
 SEED = 42
 
 

--- a/test/measurement_calibration/test_meas.py
+++ b/test/measurement_calibration/test_meas.py
@@ -44,6 +44,8 @@ from qiskit.ignis.mitigation.measurement \
              MeasurementFilter)
 from qiskit.ignis.verification.tomography import count_keys
 
+# fixed seed for tests
+SEED = 42
 
 class TestMeasCal(unittest.TestCase):
     # TODO: after terra 0.8, derive test case like this
@@ -186,7 +188,8 @@ class TestMeasCal(unittest.TestCase):
         # Run the calibration circuits
         backend = Aer.get_backend('qasm_simulator')
         job = qiskit.execute(meas_calibs, backend=backend,
-                             shots=self.shots)
+                             shots=self.shots,
+                             seed_simulator=SEED)
         cal_results = job.result()
 
         # Make a calibration matrix
@@ -195,7 +198,8 @@ class TestMeasCal(unittest.TestCase):
         fidelity = meas_cal.readout_fidelity()
 
         job = qiskit.execute([ghz], backend=backend,
-                             shots=self.shots)
+                             shots=self.shots,
+                             seed_simulator=SEED)
         results = job.result()
 
         # Predicted equally distributed results
@@ -345,7 +349,8 @@ class TestMeasCal(unittest.TestCase):
         # Run the calibration circuits
         backend = Aer.get_backend('qasm_simulator')
         cal_results = qiskit.execute(meas_calibs, backend=backend,
-                                     shots=self.shots).result()
+                                     shots=self.shots,
+                                     seed_simulator=SEED).result()
 
         # Make a calibration matrix
         meas_cal = TensoredMeasFitter(cal_results,
@@ -354,7 +359,8 @@ class TestMeasCal(unittest.TestCase):
         fidelity = meas_cal.readout_fidelity(0)*meas_cal.readout_fidelity(1)
 
         results = qiskit.execute([ghz], backend=backend,
-                                 shots=self.shots).result()
+                                 shots=self.shots,
+                                 seed_simulator=SEED).result()
 
         # Predicted equally distributed results
         predicted_results = {'000': 0.5,

--- a/test/measurement_calibration/test_meas.py
+++ b/test/measurement_calibration/test_meas.py
@@ -47,6 +47,7 @@ from qiskit.ignis.verification.tomography import count_keys
 # fixed seed for tests
 SEED = 42
 
+
 class TestMeasCal(unittest.TestCase):
     # TODO: after terra 0.8, derive test case like this
     # class TestMeasCal(QiskitTestCase):


### PR DESCRIPTION
### Summary
Fixes #467 
there was randomness the circuit results in the measurement calibration tests, which sometimes caused the tests to fail

### Details and comments
added a seed to the execution of the relevant circuits in the tests, to cause the tests to pass if the logic is correct
