### PR TITLE
Pin setuptools version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
             source activate qiskit-ignis
             conda config --add channels conda-forge
             conda install cvxopt -y
-            python -m pip install -c constraints.txt --upgrade pip virtualenv setuptools
+            python -m pip install -c constraints.txt --upgrade pip virtualenv 'setuptools<50'
             pip install -c constraints.txt -U tox
             tox --sitepackages
           displayName: 'Install dependencies and run tests'

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 pylint==2.4.4
 astroid==2.3.3
 pywin32==225
+setuptools==49.6.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Setuptools 50.0.0 was released recently and since then this has been
blocking windows CI because it is causing scs dependency of cvxpy to
fail to install. This commit should fix this for the time being by
capping the setuptools version we use in CI until setuptools or scs
fixes the issues.

### Details and comments