### PR TITLE
Add tutorials job to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,8 +94,7 @@ jobs:
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
           python -m pip install --upgrade pip
-          cd qiskit-tutorials
-          pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
+          pip install -U -r requirements-dev.txt -c constraints.txt
           pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
           pip install -c constraints.txt -e .
           pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
@@ -106,6 +105,7 @@ jobs:
       - name: Run Tutorials
         run: |
           set -e
+          cd qiskit-tutorials
           rm -rf tutorials/chemistry tutorials/circuits tutorials/circuits_advanced tutorials/finance tutorials/optimization tutorials/simulators
           sphinx-build -b html . _build/html
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
           python -m pip install --upgrade pip
+          cd qiskit-tutorials
           pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
           pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
           pip install -c constraints.txt -e .
@@ -105,7 +106,6 @@ jobs:
       - name: Run Tutorials
         run: |
           set -e
-          cd qiskit-tutorials
           rm -rf tutorials/chemistry tutorials/circuits tutorials/circuits_advanced tutorials/finance tutorials/optimization tutorials/simulators
           sphinx-build -b html . _build/html
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,3 +80,35 @@ jobs:
         with:
           name: html_docs
           path: docs/_build/html
+  tutorials:
+    name: tutorials
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Setup tutorials job
+        run: |
+          set -e
+          git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
+          python -m pip install --upgrade pip
+          pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
+          pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
+          pip install -c constraints.txt -e .
+          pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
+          python setup.py build_ext --inplace
+          sudo apt install -y graphviz pandoc
+          pip check
+        shell: bash
+      - name: Run Tutorials
+        run: |
+          set -e
+          cd qiskit-tutorials
+          rm -rf tutorials/chemistry tutorials/circuits tutorials/circuits_advanced tutorials/finance tutorials/optimization tutorials/simulators
+          sphinx-build -b html . _build/html
+      - uses: actions/upload-artifact@v2
+        with:
+          name: tutorials_html
+          path: qiskit-tutorials/_build/html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
           pip install -U -r requirements-dev.txt -c constraints.txt
           pip install -c constraints.txt git+https://github.com/Qiskit/qiskit-terra
           pip install -c constraints.txt -e .
-          pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
+          pip install -U "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" pylatexenc sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
           python setup.py build_ext --inplace
           sudo apt install -y graphviz pandoc
           pip check


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new job to run the qiskit tutorials in CI. The
tutorials are used as a form of upgrade testing to ensure that for key
examples Qiskit as a whole is N and N+1 releases. This caused friction
during the qiskit 0.20.0 release because the tutorials were never
updated to stop using deprecated code (or in the case of other elements
by merging backwards incompatible changes). To ensure there aren't any
surprises at the last minute when we run the tutorials with a proposed
new metapackage this commit adds a job to CI to ensure that they always
run with terra changes. It means for PRs that change an api (after a
deprecation cycle) the tutorial will need to be updated first. This will
ensure that users will have an upgrade path because CI in
qiskit/qiskit-tutorials runs with the metapackage.

### Details and comments


