### PR TITLE
Bugfix in base_fitter

### DIFF
--- a/qiskit/ignis/verification/tomography/fitters/base_fitter.py
+++ b/qiskit/ignis/verification/tomography/fitters/base_fitter.py
@@ -243,7 +243,10 @@ class TomographyFitter:
             QiskitError: In case some of the tomography data is not found
                 in the results
         """
-        if len(circuits[0].cregs) == 1:
+        if len(circuits) == 0:
+            raise QiskitError("No circuit data given")
+
+        if isinstance(circuits[0], str) or len(circuits[0].cregs) == 1:
             marginalize = False
         else:
             marginalize = True

--- a/test/tomography/test_state_tomography.py
+++ b/test/tomography/test_state_tomography.py
@@ -129,6 +129,23 @@ class TestStateTomography(unittest.TestCase):
         F_bell = state_fidelity(psi, rho, validate=False)
         self.assertAlmostEqual(F_bell, 1, places=1)
 
+    def test_fitter_string_input(self):
+        q3 = QuantumRegister(3)
+        bell = QuantumCircuit(q3)
+        bell.h(q3[0])
+        bell.cx(q3[0], q3[1])
+        bell.cx(q3[1], q3[2])
+
+        qst = tomo.state_tomography_circuits(bell, q3)
+        qst_names = [circ.name for circ in qst]
+        job = qiskit.execute(qst, Aer.get_backend('qasm_simulator'),
+                             shots=5000)
+        tomo_fit = tomo.StateTomographyFitter(job.result(), qst_names)
+        rho = tomo_fit.fit(method=self.method)
+        psi = Statevector.from_instruction(bell)
+        F_bell = state_fidelity(psi, rho, validate=False)
+        self.assertAlmostEqual(F_bell, 1, places=1)
+
 
 @unittest.skipUnless(cvx_fit._HAS_CVX, 'cvxpy is required  to run this test')
 class TestStateTomographyCVX(TestStateTomography):


### PR DESCRIPTION
This fix addresses issue #508, where one check conflicted with circuit `str` input to `TomographyFitter`