### PR TITLE
Stop using conda in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-      - uses: goanpeca/setup-miniconda@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          activate-environment: ignis
-          auto-update-conda: true
-          channels: conda-forge
           python-version: ${{ matrix.python-version }}
       - name: Pip cache
         uses: actions/cache@v2
@@ -60,8 +58,8 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
-      - name: Install cvxopt
-        run: conda install tox cvxopt -y
+      - name: Install deps
+        run: pip install -U tox cvxopt
         shell: pwsh
       - name: Install and Run Tests
         run: tox --sitepackages -epy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install deps
-        run: pip install -U tox cvxopt
+        run: pip install -U tox cvxopt setuptools virtualenv wheel
         shell: pwsh
       - name: Install and Run Tests
         run: tox --sitepackages -epy


### PR DESCRIPTION
The recent update of conda in the base images for windows CI has broken
the windows CI jobs because virtualenv is unable to discover the path to
the python binary. This commit attempts to fix this by abandoning the
conda usage and relying solely on system installed python and pip to
install the dependencies. The complexity here is that the SDP solver
installation has been problematic in windows outside of conda as cvxgrp
packages only seem to reliable ship binaries via conda for all
platforms.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


