### PR TITLE
Pin pyfakefs to avoid broken release

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -295,7 +295,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=matplotlib.cm,numpy.random,retworkx
+ignored-modules=matplotlib.cm,numpy.random,retworkx,numba
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/constraints.txt
+++ b/constraints.txt
@@ -2,3 +2,4 @@ pylint==2.4.4
 astroid==2.3.3
 pywin32==225
 setuptools==49.6.0
+pyfakefs==4.1.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent pyfakefs 4.2.0 release is raising an import error whenever
it's imported, see jmcgeheeiv/pyfakefs#565 for more details. This commit
pins the pyfakefs version to the last known working version until there
is a new release fixing this issue.

### Details and comments