### PR TITLE
Fix ignis without optional requirements installed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,32 @@ jobs:
           QISKIT_IN_PARALLEL: TRUE
         run: tox -e py
         if: runner.os == 'macOS'
+  tests-no-opt:
+    name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.8]
+        os: ["ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-${{ hashFiles('setup.py','requirements-dev.txt','constraints.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-tests-
+            ${{ runner.os }}-${{ matrix.python-version }}-pip-
+            ${{ runner.os }}-${{ matrix.python-version }}
+      - name: Install Deps
+        run: python -m pip install -U tox setuptools virtualenv wheel
+      - name: Install and Run Tests
+        run: tox -e no-opt
   windows-tests:
     name: tests-python${{ matrix.python-version }}-windows
     runs-on: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         run: tox -e py
         if: runner.os == 'macOS'
   tests-no-opt:
-    name: tests-python${{ matrix.python-version }}-${{ matrix.os }}
+    name: tests-python3.8-no-optional-dependencies
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/qiskit/ignis/mitigation/expval/base_meas_mitigator.py
+++ b/qiskit/ignis/mitigation/expval/base_meas_mitigator.py
@@ -172,7 +172,7 @@ class BaseExpvalMeasMitigator(ABC):
 
         Args:
             qubits (list): Optional, qubits being measured for operator expval.
-            ax (axes: Optional. Axes object to add plot to.
+            ax (axes): Optional. Axes object to add plot to.
 
         Returns:
             plt.axes: the figure axes object.
@@ -196,7 +196,7 @@ class BaseExpvalMeasMitigator(ABC):
 
     def plot_mitigation_matrix(self,
                                qubits=None,
-                               ax= None):
+                               ax=None):
         """Matrix plot of the readout error mitigation matrix.
 
         Args:

--- a/qiskit/ignis/mitigation/expval/base_meas_mitigator.py
+++ b/qiskit/ignis/mitigation/expval/base_meas_mitigator.py
@@ -171,7 +171,7 @@ class BaseExpvalMeasMitigator(ABC):
         """Matrix plot of the readout error assignment matrix.
 
         Args:
-            qubits (list): Optional, qubits being measured for operator expval.
+            qubits (list(int)): Optional, qubits being measured for operator expval.
             ax (axes): Optional. Axes object to add plot to.
 
         Returns:
@@ -200,7 +200,7 @@ class BaseExpvalMeasMitigator(ABC):
         """Matrix plot of the readout error mitigation matrix.
 
         Args:
-            qubits (list): Optional, qubits being measured for operator expval.
+            qubits (list(int)): Optional, qubits being measured for operator expval.
             ax (plt.axes): Optional. Axes object to add plot to.
 
         Returns:

--- a/qiskit/ignis/mitigation/expval/base_meas_mitigator.py
+++ b/qiskit/ignis/mitigation/expval/base_meas_mitigator.py
@@ -166,13 +166,13 @@ class BaseExpvalMeasMitigator(ABC):
         return gamma / np.sqrt(shots)
 
     def plot_assignment_matrix(self,
-                               qubits: Optional[List[int]] = None,
-                               ax: Optional[plt.axes] = None) -> plt.axes:
+                               qubits=None,
+                               ax=None):
         """Matrix plot of the readout error assignment matrix.
 
         Args:
-            qubits: Optional, qubits being measured for operator expval.
-            ax: Optional. Axes object to add plot to.
+            qubits (list): Optional, qubits being measured for operator expval.
+            ax (axes: Optional. Axes object to add plot to.
 
         Returns:
             plt.axes: the figure axes object.
@@ -195,13 +195,13 @@ class BaseExpvalMeasMitigator(ABC):
         return ax
 
     def plot_mitigation_matrix(self,
-                               qubits: Optional[List[int]] = None,
-                               ax: Optional[plt.axes] = None) -> plt.axes:
+                               qubits=None,
+                               ax= None):
         """Matrix plot of the readout error mitigation matrix.
 
         Args:
-            qubits: Optional, qubits being measured for operator expval.
-            ax: Optional. Axes object to add plot to.
+            qubits (list): Optional, qubits being measured for operator expval.
+            ax (plt.axes): Optional. Axes object to add plot to.
 
         Returns:
             plt.axes: the figure axes object.
@@ -247,12 +247,12 @@ class BaseExpvalMeasMitigator(ABC):
         return label
 
     @staticmethod
-    def _plot_axis(mat: np.ndarray, ax: plt.axes) -> plt.axes:
+    def _plot_axis(mat, ax):
         """Helper function for setting up axes for plots.
 
         Args:
-            mat: the N-qubit matrix to plot.
-            ax: Optional. Axes object to add plot to.
+            mat (np.ndarray): the N-qubit matrix to plot.
+            ax (plt.axes): Optional. Axes object to add plot to.
 
         Returns:
             plt.axes: the figure object and axes object.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #500 type hints were added for the plotting functions using the
optional matplotlib dependencies. This breaks ignis installations
without matplotlib present since it's an optional dependency. Since type
hints are really just for documentation and not necessary this commit
just removes those problematic hints and uses the docstring to document
the types.

At the same time the testing job verifying ignis works without any
optional dependencies that was lost in the migration from travis to
github actions is restored to verify that everything works moving
forward.

### Details and comments

Fixes #532 