### PR TITLE
Remove IBMQ provider from docs CI job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,10 +49,12 @@ commands =
 
 [testenv:docs]
 basepython = python3
+setenv =
+  {[testenv]setenv}
+  QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 deps =
     git+https://github.com/Qiskit/qiskit-terra.git
     -r{toxinidir}/requirements-dev.txt
-    qiskit-ibmq-provider
 commands =
   sphinx-build -b html -W {posargs} docs/ docs/_build/html
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A recent urllib3 release is breaking compatibility with requests which
is blocking CI in the docs job. However, requests is only ever used by
the IBMQ provider which we install in the docs job because of one
jupyter widget and to avoid a packaging warning (which would also be
fatal to the sphinx build). This commit attempts to fix the current ci
failure by removing the qiskit-ibmq-provider package from the CI job and
fixing or supressing the warnings/failures related to packaging.

### Details and comments