### PR TITLE
Fixed typo when QiskitError is raised

### DIFF
--- a/qiskit/ignis/mitigation/measurement/filters.py
+++ b/qiskit/ignis/mitigation/measurement/filters.py
@@ -112,7 +112,7 @@ class MeasurementFilter():
                 if data_label not in self._state_labels:
                     raise QiskitError("Unexpected state label '" + data_label +
                                       "', verify the fitter's state labels "
-                                      "correpsond to the input data")
+                                      "correspond to the input data")
             data_format = 0
             # convert to form2
             raw_data2 = [np.zeros(len(self._state_labels), dtype=float)]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The QiskitError for unexpected state label outputs the message:
"Unexpected state label <insert_label>, verify the fitter's state labels _correpsond_ to the input data"

There was a typo. I changed _correpsond_ to _correspond_.


