### PR TITLE
Add missing networkx dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ import sys
 requirements = [
     "numpy>=1.13",
     "qiskit-terra>=0.13.0",
+    "networkx>=2.2",
     "scipy>=0.19,!=0.19.1",
     "setuptools>=40.1.0",
     "scikit-learn>=0.17",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The topological_code fitters module relies on networkx and has had a
hard dependency on it since it was first introduced in #211. However, it
was never added to the requirements list. This was never caught because
historically qiskit-terra (which is in the requirements list) has
required networkx too so installing qiskit-terra would install networkx.
But, in Qiskit/qiskit-terra#5183 the dependency on networkx was removed
from terra. This commit corrects the issue so that we're properly
listing networkx as an ignis requirement moving forward. Longer term we
should migrate the topological codes fitter to use retworkx for better
performance and consistency with the rest of Qiskit. However, before we
can do that Qiskit/retworkx#216 must be fixed first.

### Details and comments


