### PR TITLE
Update aer check in topological codes

### DIFF
--- a/qiskit/ignis/verification/topological_codes/fitters.py
+++ b/qiskit/ignis/verification/topological_codes/fitters.py
@@ -27,7 +27,7 @@ import numpy as np
 from qiskit import QuantumCircuit, execute
 
 try:
-    from qiskit import Aer
+    from qiskit.providers.aer import Aer
     HAS_AER = True
 except ImportError:
     from qiskit import BasicAer


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In Qiskit/qiskit-terra#5619 how the qiskit.Aer provider gets loaded will
be changing and it will always be present, not just when Aer is
installed. In the topological codes fitters it was checking for the
presence of Aer using qiskit.Aer which won't continue to work moving
forward. To avoid this potential issue (and potentially unblock
Qiskit/qiskit-terra#5619) this commit switches to using
'from qiskit.providers.aer import Aer' instead which lives in the
qiskit-aer project itself and will always import error if aer isn't
installed.

### Details and comments