### PR TITLE
Use Aer from release for 3.9 test jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,10 +58,6 @@ jobs:
         run: python -m pip install -U tox setuptools virtualenv wheel cvxopt
       - name: Install and Run Tests
         run: tox --sitepackages -e py
-        if: matrix.python-version != '3.9'
-      - name: Install and Run Tests
-        run: tox --sitepackages -e py39
-        if: matrix.python-version == '3.9'
 
   tests-no-opt:
     name: tests-python3.8-no-optional-dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,6 @@ jobs:
         run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests
         run: tox -e py
-        if: matrix.python-version != '3.9'
-      - name: Install and Run Tests
-        run: tox -e py39
-        if: matrix.python-version == '3.9'
 
   tests-no-opt:
     name: tests-python3.8-no-optional-dependencies
@@ -67,8 +63,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        # TODO: Add 3.9 to the list after aer 0.8.0 release
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Add msbuild to PATH

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pylint==2.4.4
 pycodestyle
-qiskit-aer>=0.3.0;python_version<'3.9'
+qiskit-aer>=0.3.0
 scikit-learn>=0.17
 Sphinx>=2.1
 sphinx-rtd-theme>=0.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -20,14 +20,6 @@ commands =
     pip install -U -c constraints.txt -r{toxinidir}/requirements-dev.txt
     pip check
     stestr run {posargs}
-# Remove after qiskit-aer 0.8.0 release:
-[testenv:py39]
-commands =
-    pip install -U -c constraints.txt git+https://github.com/Qiskit/qiskit-terra.git
-    pip install -U -c constraints.txt git+https://github.com/Qiskit/qiskit-aer.git
-    pip install -U -c constraints.txt -r{toxinidir}/requirements-dev.txt
-    pip check
-    stestr run {posargs}
 
 [testenv:no-opt]
 deps =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #505 we added jobs for Python 3.9, but because there was no released
Aer version that supported 3.9 yet to run tests we had to rely on
building aer from source in test jobs to test that things worked as
expected in CI. Now that Aer 0.7.3 has been released this included
support for python 3.9, so we now don't need to rely on building aer
from source in CI. This commit removes the job configuration to build
Aer from source in the 3.9 jobs (both in the tox configuration and
github actions config).

### Details and comments