### PR TITLE
Fix expval mitigation bug

### DIFF
--- a/qiskit/ignis/mitigation/expval/complete_mitigator.py
+++ b/qiskit/ignis/mitigation/expval/complete_mitigator.py
@@ -17,7 +17,6 @@ Full-matrix measurement error mitigation generator.
 from typing import Optional, List, Dict, Tuple
 import numpy as np
 
-from qiskit.exceptions import QiskitError
 from .utils import (counts_probability_vector, _expval_with_stddev)
 from .base_meas_mitigator import BaseExpvalMeasMitigator
 
@@ -95,8 +94,6 @@ class CompleteExpvalMeasMitigator(BaseExpvalMeasMitigator):
         # Get qubit mitigation matrix and mitigate probs
         if qubits is None:
             qubits = tuple(range(num_qubits))
-        if len(qubits) != num_qubits:
-            raise QiskitError("Num qubits does not match number of clbits.")
         mit_mat = self.mitigation_matrix(qubits)
 
         # Get operator coeffs

--- a/qiskit/ignis/mitigation/expval/ctmp_mitigator.py
+++ b/qiskit/ignis/mitigation/expval/ctmp_mitigator.py
@@ -112,13 +112,12 @@ class CTMPExpvalMeasMitigator(BaseExpvalMeasMitigator):
             which physical qubits these bit-values correspond to as
             ``circuit.measure(qubits, clbits)``.
         """
-        if qubits is None:
-            qubits = list(range(self._num_qubits))
-
         # Convert counts to probs
         probs, shots = counts_probability_vector(
-            counts, clbits=clbits, qubits=qubits,
-            num_qubits=len(qubits), return_shots=True)
+            counts, clbits=clbits, qubits=qubits, return_shots=True)
+        num_qubits = int(np.log2(probs.shape[0]))
+        if qubits is None:
+            qubits = list(range(num_qubits))
 
         # Ensure diagonal is a numpy vector so we can use fancy indexing
         if diagonal is None:

--- a/qiskit/ignis/mitigation/expval/tensored_mitigator.py
+++ b/qiskit/ignis/mitigation/expval/tensored_mitigator.py
@@ -102,10 +102,10 @@ class TensoredExpvalMeasMitigator(BaseExpvalMeasMitigator):
             counts, clbits=clbits, return_shots=True)
         num_qubits = int(np.log2(probs.shape[0]))
 
-        if qubits is not None:
-            ainvs = self._mitigation_mats[list(qubits)]
-        else:
-            ainvs = self._mitigation_mats
+        # Get qubit mitigation matrix and mitigate probs
+        if qubits is None:
+            qubits = range(num_qubits)
+        ainvs = self._mitigation_mats[list(qubits)]
 
         # Get operator coeffs
         if diagonal is None:

--- a/releasenotes/notes/fix-expval-mit-c2c2701513129316.yaml
+++ b/releasenotes/notes/fix-expval-mit-c2c2701513129316.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes bug in expectation value error mitigation where if the `qubits`
+    kwarg was not specified it would incorrectly use the total number of
+    qubits of the mitigator, rather than the number of classical bits in the
+    count dictionary leading to greatly reduced performance.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes bug in expectation value error mitigation where if the `qubits` kwarg was not specified it would incorrectly use the total number of qubits of the mitigator, rather than the number of classical bits in the count dictionary leading to greatly reduced performance.

### Details and comments

Closes #561 
