### PR TITLE
Bump pylint version to the latest release

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,5 @@
-pylint==2.4.4
-astroid==2.3.3
+pylint==2.8.2
+astroid==2.5.6
 pywin32==225
 setuptools==49.6.0
 pyfakefs==4.1.0

--- a/qiskit/ignis/measurement/discriminator/discriminators.py
+++ b/qiskit/ignis/measurement/discriminator/discriminators.py
@@ -286,10 +286,10 @@ class BaseDiscriminationFitter(ABC):
 
         try:
             from sklearn.preprocessing import StandardScaler
-        except ImportError:
+        except ImportError as exc:
             raise ImportError("To scale the xdata scikit-learn must be "
                               "installed. This can be done with 'pip install "
-                              "scikit-learn'")
+                              "scikit-learn'") from exc
 
         if not self._scaler or refit:
             self._scaler = StandardScaler(with_std=True)

--- a/qiskit/ignis/measurement/discriminator/filters.py
+++ b/qiskit/ignis/measurement/discriminator/filters.py
@@ -125,9 +125,9 @@ class DiscriminationFilter:
             for char in expected_states[key]:
                 try:
                     value = int(char)
-                except ValueError:
+                except ValueError as exc:
                     raise QiskitError('Cannot parse character in ' +
-                                      expected_states[key])
+                                      expected_states[key]) from exc
 
                 base = base if base > value else value
 

--- a/qiskit/ignis/measurement/discriminator/iq_discriminators.py
+++ b/qiskit/ignis/measurement/discriminator/iq_discriminators.py
@@ -275,9 +275,9 @@ class IQDiscriminationFitter(BaseDiscriminationFitter):
                 zz = np.array(zz).astype(float).reshape(xx.shape)
                 axs[0].contourf(xx, yy, zz, alpha=.2)
 
-            except ValueError:
+            except ValueError as exc:
                 raise QiskitError('Cannot convert expected state labels to '
-                                  'float.')
+                                  'float.') from exc
 
         n_qubits = len(self._qubit_mask)
         if show_fitting_data:

--- a/qiskit/ignis/mitigation/expval/complete_mitigator.py
+++ b/qiskit/ignis/mitigation/expval/complete_mitigator.py
@@ -154,8 +154,8 @@ class CompleteExpvalMeasMitigator(BaseExpvalMeasMitigator):
             qubits = [qubits]
 
         # Compute marginal matrix
-        axis = tuple([self._num_qubits - 1 - i for i in set(
-            range(self._num_qubits)).difference(qubits)])
+        axis = tuple(self._num_qubits - 1 - i for i in set(
+            range(self._num_qubits)).difference(qubits))
         num_qubits = len(qubits)
         new_amat = np.zeros(2 * [2 ** num_qubits], dtype=float)
         for i, col in enumerate(self._assignment_mat.T[self._keep_indexes(qubits)]):

--- a/qiskit/ignis/verification/accreditation/fitters.py
+++ b/qiskit/ignis/verification/accreditation/fitters.py
@@ -111,5 +111,4 @@ class AccreditationFitter:
             self.bound = self.bound/(self.N_acc/self.num_runs-theta)
             self.bound = self.bound+1-self.g_num
             self.confidence = 1-2*np.exp(-2*theta*self.num_runs*self.num_runs)
-        if self.bound > 1:
-            self.bound = 1
+        self.bound = min(self.bound, 1)

--- a/qiskit/ignis/version.py
+++ b/qiskit/ignis/version.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=consider-using-with
+
 """Functions for getting version information about ignis."""
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pylint==2.4.4
+pylint==2.8.2
 pycodestyle
 qiskit-aer>=0.3.0
 scikit-learn>=0.17

--- a/test/rb/generate_data.py
+++ b/test/rb/generate_data.py
@@ -11,6 +11,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
+# pylint: disable=unbalanced-tuple-unpacking
+
 """
 Generate data for rb fitters tests
 """

--- a/test/rb/test_rb.py
+++ b/test/rb/test_rb.py
@@ -13,6 +13,7 @@
 # that they have been altered from the originals.
 
 # pylint: disable=undefined-loop-variable,invalid-name,missing-type-doc
+# pylint: disable=unbalanced-tuple-unpacking
 
 """
 Run through RB for different qubit numbers to check that it's working


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit bumps the pylint version we use for CI and local style
enforcement to be the latest release 2.8.2 and updates the code so that
the new pylint version passes. One place to note is a new rule looking
for potentially unbalanced tuple rule is disabled because the number of
values in the return tuple from the rb circuit generator varies
depending on the input (so we can't fix the code to pass the rule.
The version we were using was missing python 3.9 support and causes issues
for anyone running locally with python 3.9. This fixes this so we can
run pylint with all supported versions of python.

### Details and comments


