### PR TITLE
Update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -22,3 +22,14 @@ Gadi Aleksandrowicz <gadia@il.ibm.com>
 Jay M. Gambetta <jay.gambetta@us.ibm.com>
 Shelly Garion <shelly@il.ibm.com> <46566946+ShellyGarion@users.noreply.github.com>
 Yael Ben-Haim <yaelbh@il.ibm.com>
+Naoki Kanazawa <39517270+nkanazawa1989@users.noreply.github.com>
+Leron Gil <leron_1234@yahoo.com>
+Daniel Egger <38065505+eggerdj@users.noreply.github.com>
+Drew Risinger <drewrisinger@users.noreply.github.com>
+Dekel Meirom <33314493+dekelmeirom@users.noreply.github.com>
+Dekel Meirom <33314493+dekelmeirom@users.noreply.github.com> <34662967+dekool@users.noreply.github.com>
+Dennis Liu <54714046+dennis-liu-1@users.noreply.github.com>
+Seth Merkel <49210444+sethmerkel@users.noreply.github.com>
+Merav Aharoni <46567124+merav-aharoni@users.noreply.github.com>
+Jakob M. Günther <58778456+jagunther@users.noreply.github.com>
+Samuele Ferracin <50947244+SamFerracin@users.noreply.github.com>


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit makes updates to the mailmap file to map emails and real names
from the git log to a canonical form. Most of the additions made here
are for regular qiskit contributors who were using the used multiple names
or email addresses and standardizes on the form already in a mailmap file
(either in terra or other qiskit repositories).

### Details and comments


