### PR TITLE
Recreates get_subsystems_counts with marginal_counts

### DIFF
--- a/qiskit/ignis/verification/tomography/__init__.py
+++ b/qiskit/ignis/verification/tomography/__init__.py
@@ -109,6 +109,7 @@ from .fitters import TomographyFitter
 
 # Utility functions TODO: move to qiskit.quantum_info
 from .data import marginal_counts     # TODO: move to qiskit.tools
+from .data import subsystems_counts   # TODO: move to qiskit.tools
 from .data import combine_counts      # TODO: move to qiskit.tools
 from .data import expectation_counts  # TODO: move to qiskit.tools
-from .data import count_keys  # TODO: move to qiskit.tools
+from .data import count_keys          # TODO: move to qiskit.tools

--- a/qiskit/ignis/verification/tomography/data.py
+++ b/qiskit/ignis/verification/tomography/data.py
@@ -101,6 +101,26 @@ def marginal_counts(counts: Dict[str, int],
     return ret
 
 
+def subsystems_counts(counts: Dict[str, int]) -> List[Dict[str, int]]:
+    """
+    Extract all subsystems' counts from the single complete system count dictionary.
+
+    Args:
+        counts (dict): The measurement count dictionary of a complete system
+            that contains multiple classical registers for measurements s.t. the dictionary's
+            keys have space delimiters.
+    Returns:
+        list: A list of measurement count dictionaries corresponding to
+                each of the subsystems measured.
+    Example:
+        >>> subsystems_counts({'0 1 1': 5, '0 0 1': 2, '0 1 0': 3})
+        [{'0': 3, '1': 7}, {'0': 2, '1': 8}, {'0': 10}]
+    """
+    num_qubits = len(list(counts.keys())[0].replace(' ', ''))
+    return [marginal_counts(counts, [qubit])
+            for qubit in range(num_qubits)]
+
+
 def count_keys(num_qubits: int) -> List[str]:
     """Return ordered count keys.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
With the deprecation of Qiskit Aqua, `get_subsystems_counts` will be lost. This method, however, is useful when looking at individual qubit counts from a multi-qubit circuit. `marginal_counts` helps create a simple version of `get_subsystems_counts` which is what this pull request does. By using `marginal_counts`, a new `subsystems_counts` method is made.


### Details and comments
This pull request recreates basic functionality of `get_subsystems_counts` with a new `subsystems_counts` that uses the `marginal_counts` method.

Here is an example of the method:
```python
results = execute(qc, backend=backend).result()
counts = subsystems_counts(results.get_counts())
plot_histogram(counts)
```
![image](https://user-images.githubusercontent.com/25377399/127550385-dce28207-1e05-415f-8046-80ac3a22a3ae.png)

