### PR TITLE
Updated analysis.py to fix for issue#511(Wrong arguments)

### DIFF
--- a/qiskit/ignis/verification/entanglement/analysis.py
+++ b/qiskit/ignis/verification/entanglement/analysis.py
@@ -189,7 +189,7 @@ class Plotter:
             print("Upper/Lower error mitigated fidelity bounds = ",
                   round(UB_m, 3), " +/- ", round(.01*UB_m, 3), " || ",
                   round(LB_m, 3), " +/- ", round(.01*LB_m, 3))
-            (F, F_m) = (.5*(P0_m + P1_m) + np.sqrt(np.absolute(fft[qn])),
+            (F, F_m) = (.5*(P0 + P1) + np.sqrt(np.absolute(fft[qn])),
                         .5*(P0_m + P1_m) + np.sqrt(np.absolute(fft_m[qn])))
             print("Raw fidelity = ", round(F, 3), " +/- ", round(.01*F, 3))
             print("Mitigated fidelity = ", round(F_m, 3),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix for issue#511. The issue mentions that the error mitigated fidelity should be composed of P0, P1, and C, not P0_m, P1_m, and C. But in line 192, for the Fourier Analysis, we don't have to apply the mitigated values for the first term. Hence the changes have been made. The arguments P0_m and P1_m have been changed to P0 and P1.

### Details and comments
This updates have been made in the understanding that issue has a valid point. This is my first contribution for this project. Please Review and let me know if am wrong.

