### PR TITLE
The .iden gate is deprecated since terra 0.13

### DIFF
--- a/qiskit/ignis/characterization/characterization_utils.py
+++ b/qiskit/ignis/characterization/characterization_utils.py
@@ -35,10 +35,7 @@ def pad_id_gates(circuit, qr, qubit, num_of_id_gates):
 
     for _ in range(num_of_id_gates):
         circuit.barrier(qr[qubit])
-        # Maintain compatibility with 0.12 stable terra
-        # the case of .iden should be removed once terra 0.13 is stable
-        if hasattr(circuit, 'i'):
-            circuit.i(qr[qubit])
+        circuit.i(qr[qubit])
 
     circuit.barrier(qr[qubit])
     return circuit

--- a/qiskit/ignis/characterization/characterization_utils.py
+++ b/qiskit/ignis/characterization/characterization_utils.py
@@ -39,8 +39,6 @@ def pad_id_gates(circuit, qr, qubit, num_of_id_gates):
         # the case of .iden should be removed once terra 0.13 is stable
         if hasattr(circuit, 'i'):
             circuit.i(qr[qubit])
-        else:
-            circuit.iden(qr[qubit])
 
     circuit.barrier(qr[qubit])
     return circuit


### PR DESCRIPTION
The .iden gate is deprecated since terra 0.13

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The latest stable Terra uses .i() or .id() for identity gate and the .iden() is deprecated since terra 0.13

### Details and comments


