### PR TITLE
Unconditionally depend on jupyter_sphinx for dev

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,8 +8,7 @@ sphinx-tabs>=1.1.11
 sphinx-autodoc-typehints
 stestr>=2.5.0
 ddt>=1.2.0,!=1.4.0
-jupyter;python_version<'3.9'
-jupyter-sphinx;python_version<'3.9'
+jupyter-sphinx
 reno
 matplotlib
 pyfakefs


### PR DESCRIPTION
### Summary

The original constraint was added in gh-505, at a time when Aer was
specifically requiring jupyter_sphinx in its own `requirements-dev.txt`
under certain constraints.  The constraint no longer appears to be
needed, so all it serves to do now is to cause the docs build to fail on
Python 3.9.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

While Ignis is still in the metapackage, its docs need to be able to build under its constraints.  This PR is part of Qiskit/qiskit#1400, updating the dependencies of the docs build, and is effectively the same as Qiskit/qiskit-aer#1429.
