### PR TITLE
Update README.md: `pip install qiskit` no longer installs all elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ to where it now lives after this move.
 
 ## Installation
 
-We encourage installing Qiskit via the PIP tool (a python package manager), which installs all Qiskit elements, including this one.
+We encourage installing Qiskit via the pip tool (a python package manager). The following command installs the core Qiskit components, including Ignis.
 
 ```bash
 pip install qiskit
 ```
 
-PIP will handle all dependencies automatically for us and you will always install the latest (and well-tested) version.
+Pip will handle all dependencies automatically for us and you will always install the latest (and well-tested) version.
 
 To install from source, follow the instructions in the [contribution guidelines](./CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-ignis.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)[![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit-ignis/master.svg?style=popout-square)](https://travis-ci.com/Qiskit/qiskit-ignis)[![](https://img.shields.io/github/release/Qiskit/qiskit-ignis.svg?style=popout-square)](https://github.com/Qiskit/qiskit-ignis/releases)[![](https://img.shields.io/pypi/dm/qiskit-ignis.svg?style=popout-square)](https://pypi.org/project/qiskit-ignis/)
 
 **_NOTE_** _As of the version 0.7.0 Qiskit Ignis is deprecated and has been
-supersceded by the
+superseded by the
 [Qiskit Experiments](https://github.com/Qiskit/qiskit-experiments) project.
 Active development on the project has stopped and only compatibility fixes
 and other critical bugfixes will be accepted until the project is officially


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Following up on https://github.com/Qiskit/qiskit-terra/pull/7476#issuecomment-1023426712

### Details and comments

I assume that one day in the not-too-distant future, `pip install qiskit` will no longer install Ignis since it is deprecated.  Given this, it might make sense right now to revise the command to say `pip install qiskit qiskit-ignis`, and to, before that, say "The following command installs the core Qiskit components as well as Ignis."

Thoughts?