### PR TITLE
Drop 3.6 testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
         run: tox -e no-opt
   windows-tests:
     name: tests-python${{ matrix.python-version }}-windows
-    runs-on: windows-latest
+    runs-on: 'windows-2019'
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     runs-on: 'windows-2019'
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Add msbuild to PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
         os: ["macOS-latest"]
     steps:
       - uses: actions/checkout@v2
@@ -90,7 +90,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Add msbuild to PATH

--- a/constraints.txt
+++ b/constraints.txt
@@ -5,3 +5,4 @@ setuptools==49.6.0
 pyfakefs==4.1.0
 cvxpy==1.1.7
 scs==2.1.4
+cvxopt==1.2.7

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,3 +4,4 @@ pywin32==225
 setuptools==49.6.0
 pyfakefs==4.1.0
 cvxpy==1.1.7
+scs==2.1.4

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ deps = numpy>=1.16.3
        setuptools>=40.1.0
 passenv = QISKIT_IN_PARALLEL
 commands =
-    pip install -U -c constraints.txt git+https://github.com/Qiskit/qiskit-terra.git
     pip install -U -c constraints.txt -r{toxinidir}/requirements-dev.txt
     pip install -c constraints.txt cvxpy<1.1.8
     pip check
@@ -23,7 +22,6 @@ commands =
 
 [testenv:no-opt]
 deps =
-    git+https://github.com/Qiskit/qiskit-terra.git
     qiskit-aer
     ddt>=1.2.0,!=1.4.0
     stestr>=2.5.0
@@ -35,7 +33,6 @@ commands =
 [testenv:lint]
 basepython = python3
 deps =
-  git+https://github.com/Qiskit/qiskit-terra.git
   qiskit-aer
   scikit-learn>=0.17
   ddt
@@ -53,7 +50,6 @@ setenv =
   {[testenv]setenv}
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 deps =
-    git+https://github.com/Qiskit/qiskit-terra.git
     -r{toxinidir}/requirements-dev.txt
 commands =
   sphinx-build -b html {posargs} docs/ docs/_build/html


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Upstream Qiskit has dropped support for python 3.6. Since ignis is in
maintenance mode pending archive we can just drop testing for this. This
commit does this and removes the python 3.6 job. Since we're not doing
active feature development anymore we don't have to worry too much about
Python 3.6 compat. If need to release again before the archive we can
revisit the minimum supported python version in that release. As ignis
is pure Python there are less compatibility issues to worry about.

### Details and comments