### PR TITLE
Remove the future tense in Migration Guide for mitigation modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ was migrated into the `qiskit-experiments` package and into `qiskit-terra`.
 
 * Ignis mitigation module
 
-  * The readout mitigator are in [`qiskit-terra`](https://github.com/Qiskit/qiskit-terra): [`qiskit.utils.mitigation`](https://qiskit.org/documentation/apidoc/utils_mitigation.html).
+  * The readout mitigator is in [`qiskit-terra`](https://github.com/Qiskit/qiskit-terra): [`qiskit.utils.mitigation`](https://qiskit.org/documentation/apidoc/utils_mitigation.html).
   * Experiments for generating the readout mitigators is in  [`qiskit-experiments`](https://github.com/Qiskit/qiskit-experiments): [local readout error characterization experiment](https://qiskit.org/documentation/experiments/stubs/qiskit_experiments.library.characterization.LocalReadoutError.html) and [correlated readout error characterization experiment](https://qiskit.org/documentation/experiments/stubs/qiskit_experiments.library.characterization.CorrelatedReadoutError.html) 
   * For use of mitigators with `qiskit.algorithms` and the [`QuantumInstance` class](https://qiskit.org/documentation/stubs/qiskit.utils.QuantumInstance.html?highlight=quantuminstance#qiskit.utils.QuantumInstance)
     this has been integrated into `qiskit-terra` directly with the `QuantumInstance`.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ was migrated into the `qiskit-experiments` package and into `qiskit-terra`.
 
 * Ignis mitigation module
 
-  * The readout mitigator will be soon added to [`qiskit-terra`](https://github.com/Qiskit/qiskit-terra).
-  * Experiments for generating the readout mitigators will be added to [`qiskit-experiments`](https://github.com/Qiskit/qiskit-experiments)
+  * The readout mitigator are in [`qiskit-terra`](https://github.com/Qiskit/qiskit-terra): [`qiskit.utils.mitigation`](https://qiskit.org/documentation/apidoc/utils_mitigation.html).
+  * Experiments for generating the readout mitigators is in  [`qiskit-experiments`](https://github.com/Qiskit/qiskit-experiments): [local readout error characterization experiment](https://qiskit.org/documentation/experiments/stubs/qiskit_experiments.library.characterization.LocalReadoutError.html) and [correlated readout error characterization experiment](https://qiskit.org/documentation/experiments/stubs/qiskit_experiments.library.characterization.CorrelatedReadoutError.html) 
   * For use of mitigators with `qiskit.algorithms` and the [`QuantumInstance` class](https://qiskit.org/documentation/stubs/qiskit.utils.QuantumInstance.html?highlight=quantuminstance#qiskit.utils.QuantumInstance)
     this has been integrated into `qiskit-terra` directly with the `QuantumInstance`.
   

--- a/qiskit/ignis/verification/quantum_volume/circuits.py
+++ b/qiskit/ignis/verification/quantum_volume/circuits.py
@@ -44,7 +44,7 @@ def qv_circuits(qubit_lists, ntrials=1,
         seed (int): An optional RNG seed to use for the generated circuit
 
     Returns:
-        tuple: A tuple of the type (``circuits``, ``circuits_nomeas``) wheere:
+        tuple: A tuple of the type (``circuits``, ``circuits_nomeas``) where:
             ``circuits`` is a list of lists of circuits for the qv sequences
             (separate list for each trial) and `` circuitss_nomeas`` is the
             same circuits but with no measurements for the ideal simulation


### PR DESCRIPTION
The Migration Guide has some promises on where things _will_ be. Some of those are already in place so adding the reference for them.

(and a small typo in the docs)